### PR TITLE
do not use risklib.Curve to describe Hazard Curves

### DIFF
--- a/risklib/vulnerability_function.py
+++ b/risklib/vulnerability_function.py
@@ -53,26 +53,21 @@ class VulnerabilityFunction(object):
         self.distribution = distribution
 
         # Check for proper IML ordering:
-        assert self._imls == sorted(set(self._imls)),\
-        "IML values must be in ascending order with no duplicates."
+        assert self._imls == sorted(set(self._imls))
 
         # Check for proper IML values (> 0.0).
-        assert all(x >= 0.0 for x in self._imls),\
-        "IML values must be >= 0.0."
+        assert all(x >= 0.0 for x in self._imls)
 
         # Check CoV and loss ratio list lengths:
-        assert len(self._covs) == len(self._imls),\
-        "CoV list should be the same length as the IML list."
-        assert len(self._loss_ratios) == len(self._imls),\
-        "Loss ratio list should be the same length as the IML list."
+        assert len(self._covs) == len(self._imls)
+
+        assert len(self._loss_ratios) == len(self._imls)
 
         # Check for proper CoV values (>= 0.0):
-        assert all(x >= 0.0 for x in self._covs),\
-        "CoV values must be >= 0.0."
+        assert all(x >= 0.0 for x in self._covs)
 
         # Check for proper loss ratio values (0.0 <= value <= 1.0):
-        assert all(x >= 0.0 and x <= 1.0 for x in self._loss_ratios),\
-        "Loss ratio values must be in the interval [0.0, 1.0]."
+        assert all(x >= 0.0 and x <= 1.0 for x in self._loss_ratios)
 
     def __eq__(self, other):
         """
@@ -80,10 +75,10 @@ class VulnerabilityFunction(object):
         """
         if not isinstance(other, VulnerabilityFunction):
             return False
-        return allclose(self.imls, other.imls)\
-               and allclose(self.loss_ratios, other.loss_ratios)\
-               and allclose(self.covs, other.covs) and\
-               self.distribution == other.distribution
+        return (allclose(self.imls, other.imls)
+                and allclose(self.loss_ratios, other.loss_ratios)
+                and allclose(self.covs, other.covs) and
+                self.distribution == other.distribution)
 
     @property
     def imls(self):

--- a/tests/classical_test.py
+++ b/tests/classical_test.py
@@ -131,12 +131,12 @@ class ClassicalTestCase(unittest.TestCase):
         self.assertTrue(allclose(expected_lrem, lrem, rtol=0.0, atol=0.0005))
 
     def test_lrem_po_computation(self):
-        hazard_curve = Curve([
+        hazard_curve = [
             (0.01, 0.99), (0.08, 0.96),
             (0.17, 0.89), (0.26, 0.82),
             (0.36, 0.70), (0.55, 0.40),
             (0.70, 0.01),
-        ])
+        ]
 
         imls = [0.1, 0.2, 0.4, 0.6]
         covs = [0.5, 0.3, 0.2, 0.1]
@@ -157,12 +157,12 @@ class ClassicalTestCase(unittest.TestCase):
         self.assertTrue(allclose(0.00, lrem_po[10][0], atol=0.005))
 
     def test_poos(self):
-        hazard_curve = Curve([
+        hazard_curve = [
             (0.01, 0.99), (0.08, 0.96),
             (0.17, 0.89), (0.26, 0.82),
             (0.36, 0.70), (0.55, 0.40),
             (0.70, 0.01),
-        ])
+        ]
 
         expected_pos = [0.0673, 0.1336, 0.2931, 0.4689]
         pes = [0.05, 0.15, 0.3, 0.5, 0.7]
@@ -183,7 +183,6 @@ class ClassicalTestCase(unittest.TestCase):
 
         self.assertTrue(allclose(expected_steps,
             _mean_imls(vulnerability_function)))
-
 
     def test_split_with_real_values_from_turkey(self):
         loss_ratios = [
@@ -227,11 +226,11 @@ class ClassicalTestCase(unittest.TestCase):
         self.assertEqual(56, len(_evenly_spaced_loss_ratios(loss_ratios, 5)))
 
     def test_compute_loss_ratio_curve(self):
-        hazard_curve = Curve([
+        hazard_curve = [
             (0.01, 0.99), (0.08, 0.96),
             (0.17, 0.89), (0.26, 0.82),
             (0.36, 0.70), (0.55, 0.40),
-            (0.70, 0.01)])
+            (0.70, 0.01)]
 
         imls = [0.1, 0.2, 0.4, 0.6]
         covs = [0.5, 0.3, 0.2, 0.1]


### PR DESCRIPTION
Now, the public interface of the risklib requires that the hazard input is passed as standard types (list, tuple, numpy.ndarray), instead of shapes.Curve / risklib.Curve
