### PR TITLE
renamed mean_loss to average_loss

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -529,17 +529,12 @@ def bcr(eal_original, eal_retrofitted, interest_rate,
             / (interest_rate * retrofitting_cost))
 
 
-def mean_loss(losses, poes):
+def average_loss(losses, poes):
     """
-    Compute the mean loss (or loss ratio) for the given curve.
-    For instance, for a curve with four values [(x1, y1), (x2, y2), (x3, y3),
-    (x4, y4)], returns
+    Given a loss curve with `poes` over `losses` defined on a given
+    time span it computes the average loss on this period of time
+    """
 
-     x1 + 2x2 + x3  x2 + 2x3 + x4     y1 - y3  y2 - y4
-    (-------------, -------------) . (-------, -------)
-           4              4               2        4
-    """
-    # FIXME. Needs more documentation.
     mean_ratios = pairwise_mean(pairwise_mean(losses))
     mean_pes = pairwise_diff(pairwise_mean(poes))
     return numpy.dot(mean_ratios, mean_pes)

--- a/openquake/risklib/tests/benefit_cost_ratio_test.py
+++ b/openquake/risklib/tests/benefit_cost_ratio_test.py
@@ -17,8 +17,7 @@
 import unittest
 
 from openquake.risklib.curve import Curve
-from openquake.risklib.scientific import (
-    bcr, mean_loss)
+from openquake.risklib import scientific
 
 
 class RiskCommonTestCase(unittest.TestCase):
@@ -32,8 +31,9 @@ class RiskCommonTestCase(unittest.TestCase):
         life_expectancy = 40
         expected_result = 0.43405
 
-        result = bcr(eal_orig, eal_retrofitted, interest,
-                     life_expectancy, 1, retrofitting_cost)
+        result = scientific.bcr(
+            eal_orig, eal_retrofitted, interest,
+            life_expectancy, 1, retrofitting_cost)
         self.assertAlmostEqual(result, expected_result, delta=2e-5)
 
     def test_mean_curve_computation(self):
@@ -42,5 +42,7 @@ class RiskCommonTestCase(unittest.TestCase):
                                   (0.24, 0.019), (0.3, 0.009), (0.45, 0)])
 
         self.assertAlmostEqual(
-            0.023305, mean_loss(loss_ratio_curve.abscissae,
-                                loss_ratio_curve.ordinates), 3)
+            0.023305,
+            scientific.average_loss(
+                loss_ratio_curve.abscissae,
+                loss_ratio_curve.ordinates), 3)

--- a/qa_tests/bcr_test.py
+++ b/qa_tests/bcr_test.py
@@ -61,11 +61,11 @@ class BCRTestCase(unittest.TestCase):
         retrofitted_losses = (
             retrofitted_loss_ratio_curve.abscissae)
 
-        eal_original = scientific.mean_loss(
+        eal_original = scientific.average_loss(
             original_losses,
             original_loss_ratio_curve.ordinates)
 
-        eal_retrofitted = scientific.mean_loss(
+        eal_retrofitted = scientific.average_loss(
             retrofitted_losses,
             retrofitted_loss_ratio_curve.ordinates)
 


### PR DESCRIPTION
Changes required for https://bugs.launchpad.net/openquake/+bug/1152237
