### PR TITLE
Minor optimizations by using memoization

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -98,6 +98,7 @@ class VulnerabilityFunction(object):
 
         self.distribution.init(asset_count, sample_num, seed, correlation)
 
+    @utils.memoized
     def strictly_increasing(self):
         """
         :returns:
@@ -242,6 +243,7 @@ class VulnerabilityFunction(object):
                     loss_ratio, mean_loss_ratio, stddev)
         return loss_ratios, lrem
 
+    @utils.memoized
     def mean_imls(self):
         """
         Compute the mean IMLs (Intensity Measure Level)


### PR DESCRIPTION
In the context of risk classical psha based workflow, a couple of method of the VulnerabilityFunction are called several times for each asset of a given taxonomy in the exposure model. As the number of vulnerability functions is small and the method does not have any other input parameter, it is safe to memoize such methods.
