### PR TITLE
Added MeanLossTestCase and some comments/docstrings

### DIFF
--- a/openquake/risklib/workflows.py
+++ b/openquake/risklib/workflows.py
@@ -665,6 +665,7 @@ class Scenario(object):
         loss_ratio_matrix = self.vulnerability_functions[loss_type].apply_to(
             ground_motion_values, epsilons)
 
+        # aggregating per asset, getting a vector of R elements
         aggregate_losses = numpy.sum(
             loss_ratio_matrix.transpose() * values, axis=1)
 


### PR DESCRIPTION
Added a test case explaining the ordering issue described in https://bugs.launchpad.net/oq-engine/+bug/1361533.
A change in the engine will follow. The risk tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/35
