### PR TITLE
Moved the mask for arrays with missing costs in the engine

### DIFF
--- a/openquake/risklib/workflows.py
+++ b/openquake/risklib/workflows.py
@@ -717,14 +717,7 @@ class Scenario(Workflow):
         self.insured_losses = insured_losses
 
     def __call__(self, loss_type, assets, ground_motion_values, epsilons):
-        # ignore missing values, i.e. costs which are None
-        vals = []
-        mask = []
-        for a in assets:
-            val = a.value(loss_type)
-            vals.append(val)
-            mask.append(val is None)
-        values = numpy.ma.masked_values(vals, mask)
+        values = numpy.array([a.value(loss_type) for a in assets])
 
         # a matrix of N x R elements
         loss_ratio_matrix = self.risk_functions[loss_type].apply_to(


### PR DESCRIPTION
This is the companion to https://github.com/gem/oq-engine/pull/1627.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/150/
