### PR TITLE
Added a check for duplicated branchset IDs

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1027,6 +1027,7 @@ class GsimLogicTree(object):
     def _parse_lt(self):
         # do the parsing, called at instantiation time to populate .values
         fkeys = []
+        branchsetids = set()
         nrml = node_from_xml(self.fname)
         for branching_level in nrml.logicTree:
             if len(branching_level) > 1:
@@ -1038,6 +1039,12 @@ class GsimLogicTree(object):
                     raise InvalidLogicTree(
                         'only uncertainties of type '
                         '"gmpeModel" are allowed in gmpe logic tree')
+                bsid = branchset['branchSetID']
+                if bsid in branchsetids:
+                    raise InvalidLogicTree(
+                        'Duplicated branchSetID %s' % bsid)
+                else:
+                    branchsetids.add(bsid)
                 fkey = branchset.attrib.get(self.branchset_filter)
                 if fkey:
                     fkeys.append(fkey)

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1516,6 +1516,42 @@ class GsimLogicTreeTestCase(unittest.TestCase):
         self.parse_invalid(xml, logictree.InvalidLogicTree,
                            'Branching level bl1 has multiple branchsets')
 
+    def test_branchset_id_not_unique(self):
+        xml = _make_nrml("""\
+            <logicTree logicTreeID="lt1">
+              <logicTreeBranchingLevel branchingLevelID="bl1">
+                <logicTreeBranchSet uncertaintyType="gmpeModel"
+                                    branchSetID="bs1"
+                  applyToTectonicRegionType="Shield">
+                  <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>ChiouYoungs2008</uncertaintyModel>
+                    <uncertaintyWeight>0.7</uncertaintyWeight>
+                  </logicTreeBranch>
+                  <logicTreeBranch branchID="b2">
+                    <uncertaintyModel>SadighEtAl1997</uncertaintyModel>
+                    <uncertaintyWeight>0.3</uncertaintyWeight>
+                  </logicTreeBranch>
+                </logicTreeBranchSet>
+              </logicTreeBranchingLevel>
+              <logicTreeBranchingLevel branchingLevelID="bl2">
+                <logicTreeBranchSet uncertaintyType="gmpeModel"
+                                    branchSetID="bs1"
+                  applyToTectonicRegionType="Subduction Interface">
+                  <logicTreeBranch branchID="b3">
+                    <uncertaintyModel>ChiouYoungs2008</uncertaintyModel>
+                    <uncertaintyWeight>0.6</uncertaintyWeight>
+                  </logicTreeBranch>
+                  <logicTreeBranch branchID="b4">
+                    <uncertaintyModel>SadighEtAl1997</uncertaintyModel>
+                    <uncertaintyWeight>0.4</uncertaintyWeight>
+                  </logicTreeBranch>
+                </logicTreeBranchSet>
+              </logicTreeBranchingLevel>
+            </logicTree>
+        """)
+        self.parse_invalid(
+            xml, logictree.InvalidLogicTree, "Duplicated branchSetID bs1")
+
     def test_invalid_gsim(self):
         xml = _make_nrml("""\
         <logicTree logicTreeID="lt1">


### PR DESCRIPTION
I discovered that the Swiss GMPE model used by Laurentiu had a duplicated branch set ID causing a misinterpretation of the logic tree (https://bugs.launchpad.net/oq-engine/+bug/1405364).
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/169/