### PR TITLE
Small refactoring the export mechanism

### DIFF
--- a/openquake/commonlib/calculators/classical_damage.py
+++ b/openquake/commonlib/calculators/classical_damage.py
@@ -89,6 +89,7 @@ class ClassicalDamageCalculator(base.RiskCalculator):
         exported = {}
         for rlz_idx in sorted(result):
             fname = 'damage_%d.csv' % rlz_idx
-            exported += export('classical_damage_csv', self.oqparam.export_dir,
+            exported += export(('classical_damage', 'csv'),
+                               self.oqparam.export_dir,
                                fname, dmg_states, result[rlz_idx])
         return exported

--- a/openquake/commonlib/calculators/hazard.py
+++ b/openquake/commonlib/calculators/hazard.py
@@ -114,7 +114,7 @@ class ClassicalCalculator(base.HazardCalculator):
             smlt_path = '_'.join(rlz.sm_lt_path)
             gsimlt_path = '_'.join(rlz.gsim_lt_path)
             for fmt in exports:
-                key = 'hazard_curves_' + fmt
+                key = ('hazard_curves', fmt)
                 fname = 'hazard_curve-smltp_%s-gsimltp_%s-ltr_%d.%s' % (
                     smlt_path, gsimlt_path, rlz.ordinal, fmt)
                 saved += export(
@@ -131,7 +131,7 @@ class ClassicalCalculator(base.HazardCalculator):
         for fmt in exports:
             fname = 'hazard_curve-mean.%s' % fmt
             saved += export(
-                'hazard_curves_' + fmt,
+                ('hazard_curves', fmt),
                 oq.export_dir, fname, self.sitecol, mean_curves,
                 oq.imtls, oq.investigation_time)
         return saved
@@ -229,10 +229,10 @@ class ScenarioCalculator(base.HazardCalculator):
     def post_execute(self, result):
         """
         :param result: a dictionary imt -> gmfs
-        :returns: a dictionary {'gmf_xml': <gmf.xml filename>}
+        :returns: a dictionary {('gmf', 'xml'): <gmf.xml filename>}
         """
         logging.info('Exporting the result')
         out = export(
-            'gmf_xml', self.oqparam.export_dir,
+            ('gmf', 'xml'), self.oqparam.export_dir,
             self.sitecol, self.tags, result)
         return out

--- a/openquake/commonlib/calculators/scenario_damage.py
+++ b/openquake/commonlib/calculators/scenario_damage.py
@@ -114,16 +114,16 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             dd_total.append(DmgDistTotal(dmg_state, mean, std))
 
         # export
-        f1 = export('dmg_dist_per_asset_xml', self.oqparam.export_dir,
+        f1 = export(('dmg_dist_per_asset', 'xml'), self.oqparam.export_dir,
                     dmg_states, dd_asset)
-        f2 = export('dmg_dist_per_taxonomy_xml', self.oqparam.export_dir,
+        f2 = export(('dmg_dist_per_taxonomy', 'xml'), self.oqparam.export_dir,
                     dmg_states, dd_taxo)
-        f3 = export('dmg_dist_total_xml', self.oqparam.export_dir,
+        f3 = export(('dmg_dist_total', 'xml'), self.oqparam.export_dir,
                     dmg_states, dd_total)
         max_damage = dmg_states[-1]
         # the collapse map is extracted from the damage distribution per asset
         # (dda) by taking the value corresponding to the maximum damage
         collapse_map = [dda for dda in dd_asset if dda.dmg_state == max_damage]
-        f4 = export('collapse_map_xml', self.oqparam.export_dir,
+        f4 = export(('collapse_map', 'xml'), self.oqparam.export_dir,
                     dmg_states, collapse_map)
         return f1 + f2 + f3 + f4

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -132,7 +132,7 @@ class GmfCollection(object):
         yield GmfSet(gmfset)
 
 
-@export.add('gmf_xml')
+@export.add(('gmf', 'xml'))
 def export_gmf_xml(key, export_dir, sitecol, rupture_tags, gmfs):
     """
     :param key: output_type and export_type
@@ -141,7 +141,7 @@ def export_gmf_xml(key, export_dir, sitecol, rupture_tags, gmfs):
     :rupture_tags: a list of rupture tags
     :gmfs: a dictionary of ground motion fields keyed by IMT
     """
-    dest = os.path.join(export_dir, key.replace('_xml', '.xml'))
+    dest = os.path.join(export_dir, '%s.%s' % key)
     writer = hazard_writers.EventBasedGMFXMLWriter(
         dest, sm_lt_path='', gsim_lt_path='')
     with floatformat('%12.8E'):
@@ -149,7 +149,7 @@ def export_gmf_xml(key, export_dir, sitecol, rupture_tags, gmfs):
     return {key: dest}
 
 
-@export.add('gmf_csv')
+@export.add(('gmf', 'csv'))
 def export_gmf_csv(key, export_dir, sitecol, rupture_tags, gmfs):
     """
     :param key: output_type and export_type
@@ -158,7 +158,7 @@ def export_gmf_csv(key, export_dir, sitecol, rupture_tags, gmfs):
     :rupture_tags: a list of rupture tags
     :gmfs: a dictionary of ground motion fields keyed by IMT
     """
-    dest = os.path.join(export_dir, key.replace('_csv', '.csv'))
+    dest = os.path.join(export_dir, '%s.%s' % key)
     with floatformat('%12.8E'), open(dest, 'w') as f:
         for imt, gmf in gmfs.iteritems():
             for site, gmvs in zip(sitecol, gmf):
@@ -171,7 +171,7 @@ def export_gmf_csv(key, export_dir, sitecol, rupture_tags, gmfs):
 HazardCurve = collections.namedtuple('HazardCurve', 'location poes')
 
 
-@export.add('hazard_curves_csv')
+@export.add(('hazard_curves', 'csv'))
 def export_hazard_curves_csv(key, export_dir, fname, sitecol, curves_by_imt,
                              imtls, investigation_time=None):
     """
@@ -192,7 +192,7 @@ def export_hazard_curves_csv(key, export_dir, fname, sitecol, curves_by_imt,
     return {fname: dest}
 
 
-@export.add('hazard_curves_xml')
+@export.add(('hazard_curves', 'xml'))
 def export_hazard_curves_xml(key, export_dir, fname, sitecol, curves_by_imt,
                              imtls, investigation_time):
     """
@@ -232,7 +232,7 @@ def export_hazard_curves_xml(key, export_dir, fname, sitecol, curves_by_imt,
     return {fname: dest}
 
 
-@export.add('hazard_stats_csv')
+@export.add(('hazard_stats', 'csv'))
 def export_stats_csv(key, export_dir, fname, sitecol, data_by_imt):
     """
     Export the scalar outputs.

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -25,16 +25,15 @@ from openquake.commonlib import risk_writers
 from openquake.commonlib.writers import scientificformat
 
 
-@export.add('dmg_dist_per_asset_xml', 'dmg_dist_per_taxonomy_xml',
-            'dmg_dist_total_xml', 'collapse_map_xml')
+@export.add(('dmg_dist_per_asset', 'xml'), ('dmg_dist_per_taxonomy', 'xml'),
+            ('dmg_dist_total', 'xml'), ('collapse_map', 'xml'))
 def export_dmg_xml(key, export_dir, damage_states, dmg_data):
-    dest = os.path.join(export_dir, key.replace('_xml', '.xml'))
-    risk_writers.DamageWriter(damage_states).to_nrml(
-        key.replace('_xml', ''), dmg_data, dest)
+    dest = os.path.join(export_dir, '%s.%s' % key)
+    risk_writers.DamageWriter(damage_states).to_nrml(key[0], dmg_data, dest)
     return AccumDict({key: dest})
 
 
-@export.add('agg_loss_csv')
+@export.add(('agg_loss', 'csv'))
 def export_agg_loss_csv(key, export_dir, aggcurves):
     """
     Export aggregate losses in CSV.
@@ -43,7 +42,7 @@ def export_agg_loss_csv(key, export_dir, aggcurves):
     :param export_dir: the export directory
     :param aggcurves: a list [(loss_type, unit, mean, stddev), ...]
     """
-    dest = os.path.join(export_dir, key.replace('_csv', '.csv'))
+    dest = os.path.join(export_dir, '%s.%s' % key)
     with open(dest, 'w') as csvfile:
         writer = csv.writer(csvfile, delimiter='|', lineterminator='\n')
         writer.writerow(['LossType', 'Unit', 'Mean', 'Standard Deviation'])
@@ -51,7 +50,7 @@ def export_agg_loss_csv(key, export_dir, aggcurves):
     return AccumDict({key: dest})
 
 
-@export.add('classical_damage_csv')
+@export.add(('classical_damage', 'csv'))
 def export_classical_damage_csv(key, export_dir, fname, damage_states,
                                 fractions_by_asset):
     """

--- a/openquake/commonlib/tests/calculators/classical_damage_test.py
+++ b/openquake/commonlib/tests/calculators/classical_damage_test.py
@@ -11,19 +11,20 @@ class ClassicalDamageCase1TestCase(CalculatorTestCase):
     def test_discrete(self):
         out = self.run_calc(case_1.__file__, 'job_discrete.ini')
         self.assertEqualFiles(
-            'expected/damage_discrete.csv', out['classical_damage_csv'])
+            'expected/damage_discrete.csv', out['classical_damage', 'csv'])
 
     @attr('qa', 'risk', 'classical_damage')
     def test_continuous(self):
         out = self.run_calc(case_1.__file__, 'job_continuous.ini')
         self.assertEqualFiles(
-            'expected/damage_continuous.csv', out['classical_damage_csv'])
+            'expected/damage_continuous.csv', out['classical_damage', 'csv'])
 
     @attr('qa', 'risk', 'classical_damage')
     def test_interpolation(self):
         out = self.run_calc(case_1.__file__, 'job_interpolation.ini')
         self.assertEqualFiles(
-            'expected/damage_interpolation.csv', out['classical_damage_csv'])
+            'expected/damage_interpolation.csv',
+            out['classical_damage', 'csv'])
 
 
 # tests with no damage limit
@@ -33,16 +34,17 @@ class ClassicalDamageCase2TestCase(CalculatorTestCase):
     def test_discrete(self):
         out = self.run_calc(case_2.__file__, 'job_discrete.ini')
         self.assertEqualFiles(
-            'expected/damage_discrete.csv', out['classical_damage_csv'])
+            'expected/damage_discrete.csv', out['classical_damage', 'csv'])
 
     @attr('qa', 'risk', 'classical_damage')
     def test_continuous(self):
         out = self.run_calc(case_2.__file__, 'job_continuous.ini')
         self.assertEqualFiles(
-            'expected/damage_continuous.csv', out['classical_damage_csv'])
+            'expected/damage_continuous.csv', out['classical_damage', 'csv'])
 
     @attr('qa', 'risk', 'classical_damage')
     def test_interpolation(self):
         out = self.run_calc(case_2.__file__, 'job_interpolation.ini')
         self.assertEqualFiles(
-            'expected/damage_interpolation.csv', out['classical_damage_csv'])
+            'expected/damage_interpolation.csv',
+            out['classical_damage', 'csv'])

--- a/openquake/commonlib/tests/calculators/scenario_damage_test.py
+++ b/openquake/commonlib/tests/calculators/scenario_damage_test.py
@@ -25,11 +25,12 @@ class ScenarioDamageTestCase(CalculatorTestCase):
     def test_case_4(self):
         out = self.run_calc(case_4.__file__, 'job_haz.ini,job_risk.ini')
         self.assertEqualFiles(
-            'expected/dmg_dist_per_asset.xml', out['dmg_dist_per_asset_xml'])
+            'expected/dmg_dist_per_asset.xml',
+            out['dmg_dist_per_asset', 'xml'])
         self.assertEqualFiles(
             'expected/dmg_dist_per_taxonomy.xml',
-            out['dmg_dist_per_taxonomy_xml'])
+            out['dmg_dist_per_taxonomy', 'xml'])
         self.assertEqualFiles(
-            'expected/dmg_dist_total.xml', out['dmg_dist_total_xml'])
+            'expected/dmg_dist_total.xml', out['dmg_dist_total', 'xml'])
         self.assertEqualFiles(
-            'expected/collapse_map.xml', out['collapse_map_xml'])
+            'expected/collapse_map.xml', out['collapse_map', 'xml'])

--- a/openquake/commonlib/tests/calculators/scenario_test.py
+++ b/openquake/commonlib/tests/calculators/scenario_test.py
@@ -42,7 +42,7 @@ class ScenarioHazardTestCase(CalculatorTestCase):
     @attr('qa', 'hazard', 'scenario')
     def test_case_1(self):
         out = self.run_calc(case_1.__file__, 'job.ini')
-        self.assertEqualFiles('expected.xml', out['gmf_xml'])
+        self.assertEqualFiles('expected.xml', out['gmf', 'xml'])
 
     @attr('qa', 'hazard', 'scenario')
     def test_case_2(self):


### PR DESCRIPTION
Now the key used in the export dictionary is not a string of the form 'name_ext' but a pair ('name', 'ext').
This is done for compatibility with the engine.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/181/