### PR TITLE
Fixed the file fragility_continuous.xml

### DIFF
--- a/openquake/qa_tests_data/scenario_damage/case_2/fragility_continuous.xml
+++ b/openquake/qa_tests_data/scenario_damage/case_2/fragility_continuous.xml
@@ -8,7 +8,7 @@
         <limitStates>LS1 LS2</limitStates>
         <ffs type="lognormal">
             <taxonomy>RC</taxonomy>
-            <IML IMT="PGA"/>
+            <IML IMT="PGA" minIML="0.1" maxIML="9.9" imlUnit="g"/>
             <ffc ls="LS1">
                 <params mean="0.2" stddev="0.05" />
             </ffc>
@@ -18,7 +18,7 @@
         </ffs>
         <ffs type="lognormal">
             <taxonomy>RM</taxonomy>
-            <IML IMT="PGA"/>
+            <IML IMT="PGA" minIML="0.1" maxIML="9.9" imlUnit="g"/>
             <ffc ls="LS1">
                 <params mean="0.25" stddev="0.08" />
             </ffc>


### PR DESCRIPTION
Somebody very bad happened here. The file fragility_continuous.xml was incorrect, missing the attributes minIML and maxIML, however Jenkins did not raise an error (!??)
See for instance https://ci.openquake.org/job/master_oq-engine/1508/consoleFull, where the test that would break (ScenarioDamageTestCase.test_case_2) for some
reason did not run. But if you run the test on a machine different from Jenkins it breaks, as it should. This is very ugly and dangerous, since bad code entered in master
without anybody noticing.