### PR TITLE
Provided a user-friendly string representation of the class RlzsAssoc

### DIFF
--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -326,7 +326,7 @@ class RlzsAssoc(collections.Mapping):
     def __str__(self):
         pairs = []
         for key in sorted(self.rlzs_assoc):
-            pairs.append(('%s-%s' % key, map(str, self.rlzs_assoc[key])))
+            pairs.append(('%s,%s' % key, map(str, self.rlzs_assoc[key])))
         return '{%s}' % '\n'.join('%s: %s' % pair for pair in pairs)
 
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -31,6 +31,9 @@ class DuplicatedID(Exception):
 
 LtRealization = collections.namedtuple(
     'LtRealization', 'ordinal sm_lt_path gsim_lt_path weight')
+LtRealization.__str__ = lambda self: '<%d,%s,%s,w=%s>' % (
+    self.ordinal, '_'.join(self.sm_lt_path), '_'.join(self.gsim_lt_path),
+    self.weight)
 
 
 SourceModel = collections.namedtuple(
@@ -319,6 +322,12 @@ class RlzsAssoc(collections.Mapping):
 
     def __len__(self):
         return len(self.rlzs_assoc)
+
+    def __str__(self):
+        pairs = []
+        for key in sorted(self.rlzs_assoc):
+            pairs.append(('%s-%s' % key, map(str, self.rlzs_assoc[key])))
+        return '{%s}' % '\n'.join('%s: %s' % pair for pair in pairs)
 
 
 class CompositeSourceModel(collections.Sequence):

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -692,8 +692,8 @@ class CompositeSourceModelTestCase(unittest.TestCase):
         self.assertEqual(rlz, (0, ('b1', 'b5', 'b8'), ('b2', 'b3'), 0.5))
         self.assertEqual(
             str(assoc),
-            "{0-SadighEtAl1997: ['<0,b1_b5_b8,b2_b3,w=0.5>']\n"
-            "1-ChiouYoungs2008: ['<0,b1_b5_b8,b2_b3,w=0.5>']}")
+            "{0,SadighEtAl1997: ['<0,b1_b5_b8,b2_b3,w=0.5>']\n"
+            "1,ChiouYoungs2008: ['<0,b1_b5_b8,b2_b3,w=0.5>']}")
 
     def test_many_rlzs(self):
         oqparam = tests.get_oqparam('classical_job.ini')
@@ -715,15 +715,15 @@ class CompositeSourceModelTestCase(unittest.TestCase):
         self.assertEqual(map(len, csm.trt_models), [1, 1, 1, 1, 1, 1, 1, 1, 1])
         assoc = csm.get_rlzs_assoc()
         expected_assoc = """\
-{0-SadighEtAl1997: ['<0,b1_b3_b6,b3,w=0.04>']
-2-SadighEtAl1997: ['<1,b1_b3_b7,b3,w=0.12>']
-4-SadighEtAl1997: ['<2,b1_b3_b8,b3,w=0.04>']
-6-SadighEtAl1997: ['<3,b1_b4_b6,b3,w=0.12>']
-8-SadighEtAl1997: ['<4,b1_b4_b7,b3,w=0.36>']
-10-SadighEtAl1997: ['<5,b1_b4_b8,b3,w=0.12>']
-12-SadighEtAl1997: ['<6,b1_b5_b6,b3,w=0.04>']
-14-SadighEtAl1997: ['<7,b1_b5_b7,b3,w=0.12>']
-16-SadighEtAl1997: ['<8,b1_b5_b8,b3,w=0.04>']}"""
+{0,SadighEtAl1997: ['<0,b1_b3_b6,b3,w=0.04>']
+2,SadighEtAl1997: ['<1,b1_b3_b7,b3,w=0.12>']
+4,SadighEtAl1997: ['<2,b1_b3_b8,b3,w=0.04>']
+6,SadighEtAl1997: ['<3,b1_b4_b6,b3,w=0.12>']
+8,SadighEtAl1997: ['<4,b1_b4_b7,b3,w=0.36>']
+10,SadighEtAl1997: ['<5,b1_b4_b8,b3,w=0.12>']
+12,SadighEtAl1997: ['<6,b1_b5_b6,b3,w=0.04>']
+14,SadighEtAl1997: ['<7,b1_b5_b7,b3,w=0.12>']
+16,SadighEtAl1997: ['<8,b1_b5_b8,b3,w=0.04>']}"""
         self.assertEqual(str(assoc), expected_assoc)
         self.assertEqual(len(assoc.realizations), 9)
 

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -700,14 +700,15 @@ class CompositeSourceModelTestCase(unittest.TestCase):
         oqparam.number_of_logic_tree_samples = 0
         sitecol = readinput.get_site_collection(oqparam)
         csm = readinput.get_composite_source_model(oqparam, sitecol)
-        self.assertEqual(len(csm), 9)  # the smlt example has 1 x 3 x 3 paths
+        self.assertEqual(len(csm), 9)  # the smlt example has 1 x 3 x 3 paths;
+        # there are 2 distinct tectonic region types, so 18 trt_models
         rlzs = csm.get_rlzs_assoc().realizations
         self.assertEqual(len(rlzs), 18)  # the gsimlt has 1 x 2 paths
         self.assertEqual([1, 584, 1, 584, 1, 584, 1, 582, 1, 582,
                           1, 582, 1, 582, 1, 582, 1, 582],
                          map(len, csm.trt_models))
 
-        # removing trt_models
+        # removing 9 trt_models out of 18
         for trt_model in csm.trt_models:
             if trt_model.trt == 'Active Shallow Crust':  # no ruptures
                 trt_model.num_ruptures = 0

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -690,6 +690,10 @@ class CompositeSourceModelTestCase(unittest.TestCase):
                          {'Subduction Interface': 'SadighEtAl1997',
                           'Active Shallow Crust': 'ChiouYoungs2008'})
         self.assertEqual(rlz, (0, ('b1', 'b5', 'b8'), ('b2', 'b3'), 0.5))
+        self.assertEqual(
+            str(assoc),
+            "{0-SadighEtAl1997: ['<0,b1_b5_b8,b2_b3,w=0.5>']\n"
+            "1-ChiouYoungs2008: ['<0,b1_b5_b8,b2_b3,w=0.5>']}")
 
     def test_many_rlzs(self):
         oqparam = tests.get_oqparam('classical_job.ini')
@@ -709,8 +713,19 @@ class CompositeSourceModelTestCase(unittest.TestCase):
                 trt_model.num_ruptures = 0
         csm.reduce_trt_models()
         self.assertEqual(map(len, csm.trt_models), [1, 1, 1, 1, 1, 1, 1, 1, 1])
-        rlzs = csm.get_rlzs_assoc().realizations
-        self.assertEqual(len(rlzs), 9)
+        assoc = csm.get_rlzs_assoc()
+        expected_assoc = """\
+{0-SadighEtAl1997: ['<0,b1_b3_b6,b3,w=0.04>']
+2-SadighEtAl1997: ['<1,b1_b3_b7,b3,w=0.12>']
+4-SadighEtAl1997: ['<2,b1_b3_b8,b3,w=0.04>']
+6-SadighEtAl1997: ['<3,b1_b4_b6,b3,w=0.12>']
+8-SadighEtAl1997: ['<4,b1_b4_b7,b3,w=0.36>']
+10-SadighEtAl1997: ['<5,b1_b4_b8,b3,w=0.12>']
+12-SadighEtAl1997: ['<6,b1_b5_b6,b3,w=0.04>']
+14-SadighEtAl1997: ['<7,b1_b5_b7,b3,w=0.12>']
+16-SadighEtAl1997: ['<8,b1_b5_b8,b3,w=0.04>']}"""
+        self.assertEqual(str(assoc), expected_assoc)
+        self.assertEqual(len(assoc.realizations), 9)
 
         # removing all trt_models
         for trt_model in csm.trt_models:


### PR DESCRIPTION
This helps when debugging the case of multiple realizations.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/186