### PR TITLE
Create the export_dir if possible

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -277,7 +277,10 @@ class OqParam(valid.ParamSet):
         elif not os.path.exists(self.export_dir):
             # check that we can write on the parent directory
             pdir = os.path.dirname(self.export_dir)
-            return os.path.exists(pdir) and os.access(pdir, os.W_OK)
+            can_write = os.path.exists(pdir) and os.access(pdir, os.W_OK)
+            if can_write:
+                os.mkdir(self.export_dir)
+            return can_write
         return os.path.isdir(self.export_dir) and os.access(
             self.export_dir, os.W_OK)
 

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -93,6 +93,20 @@ class OqParamTestCase(unittest.TestCase):
         self.assertIn('You must set `hazard_curves_from_gmfs`',
                       str(ctx.exception))
 
+    def test_create_export_dir(self):
+        EDIR = '/tmp/nonexisting'
+        OqParam(
+            calculation_mode='event_based', inputs={},
+            sites='0.1 0.2',
+            reference_vs30_type='measured',
+            reference_vs30_value=200,
+            reference_depth_to_2pt5km_per_sec=100,
+            reference_depth_to_1pt0km_per_sec=150,
+            maximum_distance=400,
+            export_dir=EDIR,
+        ).validate()
+        self.assertTrue(os.path.exists(EDIR))
+
     def test_invalid_export_dir(self):
         with self.assertRaises(ValueError) as ctx:
             OqParam(

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -94,7 +94,7 @@ class OqParamTestCase(unittest.TestCase):
                       str(ctx.exception))
 
     def test_create_export_dir(self):
-        EDIR = '/tmp/nonexisting'
+        EDIR = os.path.join(TMP, 'nonexisting')
         OqParam(
             calculation_mode='event_based', inputs={},
             sites='0.1 0.2',


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1415855. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/219