### PR TITLE
Making some ERF parameters optional

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -45,7 +45,7 @@ CALCULATORS = HAZARD_CALCULATORS + RISK_CALCULATORS + EXPERIMENTAL_CALCULATORS
 
 class OqParam(valid.ParamSet):
     params = valid.parameters(
-        area_source_discretization=valid.positivefloat,
+        area_source_discretization=valid.NoneOr(valid.positivefloat),
         asset_correlation=valid.NoneOr(valid.FloatRange(0, 1)),
         asset_life_expectancy=valid.positivefloat,
         base_path=valid.utf8,

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -309,7 +309,7 @@ def get_source_models(oqparam, source_model_lt):
         oqparam.rupture_mesh_spacing,
         oqparam.complex_fault_mesh_spacing,
         oqparam.width_of_mfd_bin,
-        oqparam.area_source_discretization)
+        getattr(oqparam, 'area_source_discretization', None))
     samples_by_lt_path = source_model_lt.samples_by_lt_path()
 
     for i, (sm, weight, smpath, _) in enumerate(source_model_lt):
@@ -409,7 +409,7 @@ def get_composite_source_model(oqparam, sitecol):
             logging.info('Splitting sources and counting ruptures for %s',
                          trt_model)
             trt_model.split_sources_and_count_ruptures(
-                oqparam.area_source_discretization)
+                getattr(oqparam, 'area_source_discretization', None))
             logging.info('Got %s', trt_model)
         smodels.append(source_model)
     return source.CompositeSourceModel(source_model_lt, smodels)

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -165,7 +165,8 @@ def split_source(src, area_source_discretization):
     """
     if isinstance(src, source.AreaSource):
         # area_source_discretization cannot be None if there are area sources
-        assert area_source_discretization, area_source_discretization
+        assert area_source_discretization, (
+            "Please set area_source_discretization in the job.ini file")
         for s in area_to_point_sources(src, area_source_discretization):
             yield s
     elif isinstance(

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -164,6 +164,8 @@ def split_source(src, area_source_discretization):
         area source discretization
     """
     if isinstance(src, source.AreaSource):
+        # area_source_discretization cannot be None if there are area sources
+        assert area_source_discretization, area_source_discretization
         for s in area_to_point_sources(src, area_source_discretization):
             yield s
     elif isinstance(
@@ -218,9 +220,10 @@ class RuptureConverter(object):
     """
     fname = None  # should be set externally
 
-    def __init__(self, rupture_mesh_spacing, complex_fault_mesh_spacing):
+    def __init__(self, rupture_mesh_spacing, complex_fault_mesh_spacing=None):
         self.rupture_mesh_spacing = rupture_mesh_spacing
-        self.complex_fault_mesh_spacing = complex_fault_mesh_spacing
+        self.complex_fault_mesh_spacing = (
+            complex_fault_mesh_spacing or rupture_mesh_spacing)
 
     def convert_node(self, node):
         """
@@ -389,11 +392,12 @@ class SourceConverter(RuptureConverter):
     Convert sources from valid nodes into Hazardlib objects.
     """
     def __init__(self, investigation_time, rupture_mesh_spacing,
-                 complex_fault_mesh_spacing, width_of_mfd_bin,
-                 area_source_discretization):
+                 complex_fault_mesh_spacing=None, width_of_mfd_bin=1.0,
+                 area_source_discretization=None):
         self.area_source_discretization = area_source_discretization
         self.rupture_mesh_spacing = rupture_mesh_spacing
-        self.complex_fault_mesh_spacing = complex_fault_mesh_spacing
+        self.complex_fault_mesh_spacing = (
+            complex_fault_mesh_spacing or rupture_mesh_spacing)
         self.width_of_mfd_bin = width_of_mfd_bin
         self.tom = PoissonTOM(investigation_time)
 

--- a/openquake/qa_tests_data/classical/case_1/job.ini
+++ b/openquake/qa_tests_data/classical/case_1/job.ini
@@ -19,7 +19,7 @@ number_of_logic_tree_samples = 0
 rupture_mesh_spacing = 1.0
 # Not used in this test case:
 width_of_mfd_bin = 1.0
-# this test involves a point source, so there if no area_source_discretization
+# this test involves a point source, so there is no area_source_discretization
 area_source_discretization =
 
 [site_params]

--- a/openquake/qa_tests_data/classical/case_1/job.ini
+++ b/openquake/qa_tests_data/classical/case_1/job.ini
@@ -19,8 +19,8 @@ number_of_logic_tree_samples = 0
 rupture_mesh_spacing = 1.0
 # Not used in this test case:
 width_of_mfd_bin = 1.0
-# km
-area_source_discretization = 10
+# this test involves a point source, so there if no area_source_discretization
+area_source_discretization =
 
 [site_params]
 

--- a/openquake/qa_tests_data/classical/case_2/job.ini
+++ b/openquake/qa_tests_data/classical/case_2/job.ini
@@ -18,8 +18,6 @@ number_of_logic_tree_samples = 0
 # km
 rupture_mesh_spacing = 1.0
 width_of_mfd_bin = 0.001
-# km
-area_source_discretization = 10
 
 [site_params]
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1409406. In particular if a source model contains no area sources it is not necessary to set the parameter area_source_discretization in the job.ini file anymore.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/232/