### PR TITLE
Raise an error if there are assets missing the number attribute

### DIFF
--- a/docs/effective-realizations.rst
+++ b/docs/effective-realizations.rst
@@ -61,7 +61,7 @@ and let's identify the logic tree path with the notation
 == ========
 #  lt_path
 == ========
-0  `A_D`
+0   `A_D`
 1   `B_D`
 2   `C_D`
 3   `A_E`

--- a/docs/effective-realizations.rst
+++ b/docs/effective-realizations.rst
@@ -16,15 +16,22 @@ The reduction of the full logic tree happens when the actual
 sources do not span the full range of tectonic region types in the
 GMPE logic tree file. This happens practically always in SHARE calculations.
 The SHARE GMPE logic tree potentially contains 1280 realizations,
-coming from 7 different tectonic region types:
+coming from 7 different tectonic region types.
 
-Active_Shallow: 4 GMPEs
-Stable_Shallow: 5 GMPEs
-Shield: 2 GMPEs
-Subduction_Interface: 4 GMPEs
-Subduction_InSlab: 4 GMPEs
-Volcanic: 1 GMPE
-Deep: 2 GMPEs
+Active_Shallow:
+ 4 GMPEs
+Stable_Shallow:
+ 5 GMPEs
+Shield:
+ 2 GMPEs
+Subduction_Interface:
+ 4 GMPEs
+Subduction_InSlab:
+ 4 GMPEs
+Volcanic:
+ 1 GMPE
+Deep:
+ 2 GMPEs
 
 The number of paths in the full logic tree is 4 * 5 * 2 * 4 * 4 * 1 *
 2 = 1280, pretty large. However, in practice, in most computation
@@ -51,14 +58,16 @@ tectonic region type. Let's number the realizations, starting from zero,
 and let's identify the logic tree path with the notation
 `<GMPE of first region type>_<GMPE of second region type>`:
 
-# | lt_path
---+--------
-0 | A_D
-1 | B_D
-2 | C_D
-3 | A_E
-4 | B_E
-5 | C_E
+== ========
+#  lt_path
+== ========
+0  `A_D`
+1   `B_D`
+2   `C_D`
+3   `A_E`
+4   `B_E`
+5   `C_E`
+== ========
 
 Now assume that the source model does not contain sources of tectonic region
 type T1, or that such sources are filtered away since they are too distant
@@ -72,10 +81,12 @@ type because there are no sources of kind T1; so let's denote the
 path of the effective realizations with the notation
 `*_<GMPE of second region type>`:
 
-# | path
---+------
-0 | *_D
-1 | *_E
+== ======
+#   path
+== ======
+0  `*_D`
+1  `*_E`
+== ======
 
 The engine lite will export two files with a name like
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -653,8 +653,12 @@ def get_exposure(oqparam):
             asset_refs.add(asset_id)
             taxonomy = asset['taxonomy']
             if 'damage' in oqparam.calculation_mode:
+                # calculators of 'damage' kind require the 'number' attribute;
+                # if it is missing a KeyError is raised
                 number = asset.attrib['number']
             else:
+                # other calculators ignore the 'number' attribute;
+                # if it is missing it is considered None
                 number = asset.attrib.get('number')
             location = asset.location['lon'], asset.location['lat']
             if region and not geometry.Point(*location).within(region):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -652,7 +652,10 @@ def get_exposure(oqparam):
                 raise DuplicatedID(asset_id)
             asset_refs.add(asset_id)
             taxonomy = asset['taxonomy']
-            number = asset.attrib.get('number')
+            if 'damage' in oqparam.calculation_mode:
+                number = asset.attrib['number']
+            else:
+                number = asset.attrib.get('number')
             location = asset.location['lon'], asset.location['lat']
             if region and not geometry.Point(*location).within(region):
                 out_of_region += 1


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1390509. The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/251/

PS: I am also fixing the formatting of an .rst file