### PR TITLE
New vers mgmt2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: http://github.com/gem/oq-risklib
 
 Package: python-oq-risklib
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.12.1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.14.0)
 Provides: python-oq-commonlib
 Conflicts: python-oq-commonlib
 Replaces: python-oq-commonlib

--- a/openquake/risklib/__init__.py
+++ b/openquake/risklib/__init__.py
@@ -25,7 +25,7 @@ from openquake.hazardlib.general import git_suffix
 __all__ = ["VulnerabilityFunction", "DegenerateDistribution", "classical"]
 
 # the version is managed by packager.sh with a sed
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 __version__ += git_suffix(__file__)
 
 path = search_module('openquake.commonlib.general')

--- a/packager.sh
+++ b/packager.sh
@@ -285,6 +285,10 @@ _pkgtest_innervm_run () {
         oq-lite run ProbabilisticEventBased/job_hazard.ini
         "
     fi
+
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" .
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/README*" .
+
     trap ERR
 
     return

--- a/packager.sh
+++ b/packager.sh
@@ -642,7 +642,7 @@ ini_bfx="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/gp')
 ini_suf="" # currently not included into the version array structure
 
 # version info from debian/changelog
-h="$(head -n1 debian/changelog)"
+h="$(grep "^$GEM_DEB_PACKAGE" debian/changelog | head -n 1)"
 # pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1 | sed -n 's/[-+].*//gp')"
 pkg_name="$(echo "$h" | cut -d ' ' -f 1)"
 pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1)"
@@ -675,12 +675,14 @@ if [ $BUILD_DEVEL -eq 1 ]; then
 
     ( echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}) $pkg_rest"
       echo
+      echo "  [Automatic Script]"
       echo "  * Development version from $hash commit"
       echo
+      cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/q;p"
       echo " -- $DEBFULLNAME <$DEBEMAIL>  $(date -d@$dt -R)"
       echo
     )  > debian/changelog
-    cat debian/changelog.orig >> debian/changelog
+    cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/,\$ p" >> debian/changelog
     rm debian/changelog.orig
 fi
 


### PR DESCRIPTION
- implemented the new guideline for version management, on master branch we will have always the release version after the current released.
- development packages will use ```~gem...``` suffix to be **lesser than** version **without** suffix (Debian - behavior for suffixes starting with ```~``` character).
- changelog and README are copied back to jenkins folders to be able to check them, an example at:
  ```jenkins@ci.openquake.org:jobs/zdevel_oq-risklib/workspace_new_vers_mgmt2_304```