### PR TITLE
Adds support for "Backarc" parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 TAGS
 build
 dist
+*.swp

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -100,6 +100,7 @@ class OqParam(valid.ParamSet):
         reference_depth_to_2pt5km_per_sec=valid.positivefloat,
         reference_vs30_type=valid.Choice('measured', 'inferred'),
         reference_vs30_value=valid.positivefloat,
+        reference_backarc=valid.boolean,
         region=valid.coordinates,
         region_constraint=valid.wkt_polygon,
         region_grid_spacing=valid.positivefloat,
@@ -120,6 +121,8 @@ class OqParam(valid.ParamSet):
 
     def __init__(self, **names_vals):
         super(OqParam, self).__init__(**names_vals)
+        if "reference_backarc" not in names_vals:
+            self.reference_backarc = False
         if hasattr(self, 'intensity_measure_types'):
             self.hazard_imtls = dict.fromkeys(self.intensity_measure_types)
             # remove the now redundant parameter
@@ -203,7 +206,8 @@ class OqParam(valid.ParamSet):
             return (self.reference_vs30_type and
                     self.reference_vs30_value and
                     self.reference_depth_to_2pt5km_per_sec and
-                    self.reference_depth_to_1pt0km_per_sec)
+                    self.reference_depth_to_1pt0km_per_sec and
+                    self.reference_backarc)
         else:
             return True
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -121,7 +121,7 @@ class OqParam(valid.ParamSet):
 
     def __init__(self, **names_vals):
         super(OqParam, self).__init__(**names_vals)
-        if "reference_backarc" not in names_vals:
+        if not hasattr(self, 'reference_backarc'):
             self.reference_backarc = False
         if hasattr(self, 'intensity_measure_types'):
             self.hazard_imtls = dict.fromkeys(self.intensity_measure_types)
@@ -206,8 +206,7 @@ class OqParam(valid.ParamSet):
             return (self.reference_vs30_type and
                     self.reference_vs30_value and
                     self.reference_depth_to_2pt5km_per_sec and
-                    self.reference_depth_to_1pt0km_per_sec and
-                    self.reference_backarc)
+                    self.reference_depth_to_1pt0km_per_sec)
         else:
             return True
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -265,7 +265,7 @@ def get_site_collection(oqparam, mesh=None, site_ids=None,
                 get_closest(pt.longitude, pt.latitude)
             sitecol.append(
                 site.Site(pt, param.vs30, param.measured,
-                          param.z1pt0, param.z2pt5, i))
+                          param.z1pt0, param.z2pt5, param.backarc, i))
         return site.SiteCollection(sitecol)
 
     # else use the default site params

--- a/openquake/commonlib/tests/data/classical_job.ini
+++ b/openquake/commonlib/tests/data/classical_job.ini
@@ -24,6 +24,7 @@ reference_vs30_type = measured
 reference_vs30_value = 760.0
 reference_depth_to_2pt5km_per_sec = 5.0
 reference_depth_to_1pt0km_per_sec = 100.0
+reference_backarc = false
 
 [calculation]
 

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -61,6 +61,7 @@ export_dir = %s
                 'calculation_mode': 'classical',
                 'truncation_level': 0.0,
                 'random_seed': 0,
+                'reference_backarc': False,
                 'maximum_distance': 1.0,
                 'inputs': {'job_ini': job_config,
                            'site_model': site_model_input},
@@ -71,6 +72,8 @@ export_dir = %s
 
             with mock.patch('logging.warn') as warn:
                 params = vars(readinput.get_oqparam(job_config))
+                print params
+                print expected_params
                 self.assertEqual(expected_params, params)
                 self.assertEqual(['site_model', 'job_ini'],
                                  params['inputs'].keys())
@@ -114,6 +117,7 @@ export_dir = %s
                 'truncation_level': 3.0,
                 'random_seed': 5,
                 'maximum_distance': 1.0,
+                'reference_backarc': False,
                 'inputs': {'job_ini': source,
                            'sites': sites_csv},
                 'reference_depth_to_1pt0km_per_sec': 100.0,
@@ -159,20 +163,20 @@ class ClosestSiteModelTestCase(unittest.TestCase):
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.4">
     <siteModel>
-        <site lon="0.0" lat="0.0" vs30="1200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" />
-        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" />
-        <site lon="0.0" lat="0.2" vs30="200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" />
+        <site lon="0.0" lat="0.0" vs30="1200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
+        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
+        <site lon="0.0" lat="0.2" vs30="200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
     </siteModel>
 </nrml>''')
         oqparam = mock.Mock()
         oqparam.inputs = dict(site_model=data)
         expected = [
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
-                            vs30=1200.0, lon=0.0, lat=0.0),
+                            vs30=1200.0, backarc=False, lon=0.0, lat=0.0),
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
-                            vs30=600.0, lon=0.0, lat=0.1),
+                            vs30=600.0, backarc=False, lon=0.0, lat=0.1),
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
-                            vs30=200.0, lon=0.0, lat=0.2)]
+                            vs30=200.0, backarc=False, lon=0.0, lat=0.2)]
         self.assertEqual(list(readinput.get_site_model(oqparam)), expected)
 
 

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -164,7 +164,7 @@ class ClosestSiteModelTestCase(unittest.TestCase):
       xmlns="http://openquake.org/xmlns/nrml/0.4">
     <siteModel>
         <site lon="0.0" lat="0.0" vs30="1200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
-        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
+        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="True" />
         <site lon="0.0" lat="0.2" vs30="200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
     </siteModel>
 </nrml>''')
@@ -174,7 +174,7 @@ class ClosestSiteModelTestCase(unittest.TestCase):
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
                             vs30=1200.0, backarc=False, lon=0.0, lat=0.0),
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
-                            vs30=600.0, backarc=False, lon=0.0, lat=0.1),
+                            vs30=600.0, backarc=True, lon=0.0, lat=0.1),
             valid.SiteParam(z1pt0=100.0, z2pt5=2.0, measured=False,
                             vs30=200.0, backarc=False, lon=0.0, lat=0.2)]
         self.assertEqual(list(readinput.get_site_model(oqparam)), expected)

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -670,21 +670,22 @@ def ab_values(value):
 vs30_type = ChoiceCI('measured', 'inferred')
 
 SiteParam = collections.namedtuple(
-    'SiteParam', 'z1pt0 z2pt5 measured vs30 lon lat'.split())
+    'SiteParam', 'z1pt0 z2pt5 measured vs30 backarc lon lat'.split())
 
 
-def site_param(value, z1pt0, z2pt5, vs30Type, vs30, lon, lat):
+def site_param(value, z1pt0, z2pt5, vs30Type, vs30, backarc, lon, lat):
     """
     Used to convert a node like
 
        <site lon="24.7125" lat="42.779167" vs30="462" vs30Type="inferred"
-       z1pt0="100" z2pt5="5" />
+       z1pt0="100" z2pt5="5" backarc="False"/>
 
-    into a 6-tuple (z1pt0, z2pt5, measured, vs30, lon, lat)
+    into a 7-tuple (z1pt0, z2pt5, measured, vs30, backarc, lon, lat)
     """
     return SiteParam(positivefloat(z1pt0), positivefloat(z2pt5),
                      vs30_type(vs30Type) == 'measured',
-                     positivefloat(vs30), longitude(lon), latitude(lat))
+                     positivefloat(vs30), boolean(backarc),
+                     longitude(lon), latitude(lat))
 
 
 ###########################################################################

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -673,7 +673,7 @@ SiteParam = collections.namedtuple(
     'SiteParam', 'z1pt0 z2pt5 measured vs30 backarc lon lat'.split())
 
 
-def site_param(value, z1pt0, z2pt5, vs30Type, vs30, backarc, lon, lat):
+def site_param(value, z1pt0, z2pt5, vs30Type, vs30, lon, lat, backarc="false"):
     """
     Used to convert a node like
 

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -670,7 +670,7 @@ def ab_values(value):
 vs30_type = ChoiceCI('measured', 'inferred')
 
 SiteParam = collections.namedtuple(
-    'SiteParam', 'z1pt0 z2pt5 measured vs30 backarc lon lat'.split())
+    'SiteParam', 'z1pt0 z2pt5 measured vs30 lon lat backarc'.split())
 
 
 def site_param(value, z1pt0, z2pt5, vs30Type, vs30, lon, lat, backarc="false"):
@@ -684,8 +684,8 @@ def site_param(value, z1pt0, z2pt5, vs30Type, vs30, lon, lat, backarc="false"):
     """
     return SiteParam(positivefloat(z1pt0), positivefloat(z2pt5),
                      vs30_type(vs30Type) == 'measured',
-                     positivefloat(vs30), boolean(backarc),
-                     longitude(lon), latitude(lat))
+                     positivefloat(vs30), longitude(lon),
+                     latitude(lat), boolean(backarc))
 
 
 ###########################################################################


### PR DESCRIPTION
Implementation of the Abrahamson et al. (2015) GMPE requires the definition of a new site parameter ("backarc") (https://github.com/gem/oq-hazardlib/pull/308). This PR propagates the necessary changes into the risklib to allow the parameter to be read from i) the job.ini file, and ii) the site_model.xml