### PR TITLE
Fixed risklib QA tests

### DIFF
--- a/openquake/risklib/qa_tests/event_based_test.py
+++ b/openquake/risklib/qa_tests/event_based_test.py
@@ -67,7 +67,9 @@ class EventBasedTestCase(unittest.TestCase):
             'PGA', 'SOME-TAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
-            tses=10000,
+            hazard_investigation_time=50,
+            ses_per_logic_tree_path=200,
+            number_of_logic_tree_samples=0,
             loss_curve_resolution=4,
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
@@ -104,7 +106,9 @@ class EventBasedTestCase(unittest.TestCase):
             'PGA', 'SOMETAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
-            tses=10000,
+            hazard_investigation_time=50,
+            ses_per_logic_tree_path=200,
+            number_of_logic_tree_samples=0,
             loss_curve_resolution=4,
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
@@ -143,7 +147,9 @@ class EventBasedTestCase(unittest.TestCase):
             'PGA', 'SOMETAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
-            tses=10000,
+            hazard_investigation_time=50,
+            ses_per_logic_tree_path=200,
+            number_of_logic_tree_samples=0,
             loss_curve_resolution=4,
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
@@ -234,7 +240,9 @@ class EventBasedTestCase(unittest.TestCase):
             'PGA', 'SOMETAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
-            tses=10000,
+            hazard_investigation_time=50,
+            ses_per_logic_tree_path=200,
+            number_of_logic_tree_samples=0,
             loss_curve_resolution=4,
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=True

--- a/openquake/risklib/tests/workflows_test.py
+++ b/openquake/risklib/tests/workflows_test.py
@@ -42,7 +42,7 @@ class NormalizeTestCase(unittest.TestCase):
         self.vf = {self.loss_type: mock.MagicMock()}
         self.poes = [0.1, 0.2]
         self.workflow = workflows.ProbabilisticEventBased(
-            'PGA', 'TAXO', self.vf, 50, 1000, 20, self.poes, True)
+            'PGA', 'TAXO', self.vf, 50, 50, 0, 20, 20, self.poes, True)
         self.workflow.conditional_loss_poes = self.poes
         self.workflow.curves = mock.Mock(return_value=numpy.empty((3, 2, 20)))
 


### PR DESCRIPTION
Fixes the break in https://ci.openquake.org/job/master_oq-risklib/1164/ due to the API change in the event based workflow. Tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/411