### PR TITLE
Restored filtering

### DIFF
--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -640,5 +640,5 @@ def filter_sources(sources, sitecol, maxdist):
             operator.add, [])
     else:
         # few sources and sites, filter sequentially on a single core
-        sources = _filter_sources(sources, sitecol, maxdist, mon)
+        sources = _filter_sources.task_func(sources, sitecol, maxdist, mon)
     return sorted(sources, key=operator.attrgetter('source_id'))


### PR DESCRIPTION
Restored the source filtering as it was (it was temporarily removed in https://github.com/gem/oq-risklib/pull/206). The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/457/