### PR TITLE
Restored the ability to parallelize simple functions

### DIFF
--- a/openquake/commonlib/tests/parallel_test.py
+++ b/openquake/commonlib/tests/parallel_test.py
@@ -2,8 +2,7 @@ import unittest
 from openquake.commonlib import parallel
 
 
-@parallel.litetask
-def get_length(data, monitor):
+def get_length(data):
     return {'n': len(data)}
 
 
@@ -12,7 +11,7 @@ class TaskManagerTestCase(unittest.TestCase):
 
     def test_apply_reduce(self):
         res = parallel.apply_reduce(
-            get_length, (range(10), self.monitor), concurrent_tasks=3)
+            get_length, (range(10),), concurrent_tasks=3)
         self.assertEqual(res, {'n': 10})
         self.assertEqual(map(len, parallel.apply_reduce._chunks), [4, 4, 2])
 
@@ -20,7 +19,7 @@ class TaskManagerTestCase(unittest.TestCase):
     # generated even if everything is run in a single core
     def test_apply_reduce_no_tasks(self):
         res = parallel.apply_reduce(
-            get_length, ('aaabb', self.monitor), concurrent_tasks=0,
+            get_length, ('aaabb',), concurrent_tasks=0,
             key=lambda char: char)
         self.assertEqual(res, {'n': 5})
         self.assertEqual(parallel.apply_reduce._chunks,
@@ -29,7 +28,7 @@ class TaskManagerTestCase(unittest.TestCase):
     def test_spawn(self):
         all_data = [
             ('a', range(10)), ('b', range(20)), ('c', range(15))]
-        res = {key: parallel.starmap(get_length, [(data, self.monitor)])
+        res = {key: parallel.starmap(get_length, [(data,)])
                for key, data in all_data}
         for key, val in res.iteritems():
             res[key] = val.reduce()


### PR DESCRIPTION
Now oq-lite is able to parallelize regular functions again. That means that you do no need to use any decorator. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/528