### PR TITLE
Improved the `info` command to show information about the input/output weights

### DIFF
--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -46,19 +46,16 @@ def info(name, filtersources=False):
                     oqparam), []
         else:
             sitecol, assets_by_site = None, []
+        print 'Reading and filtering the source model...'
         csm = readinput.get_composite_source_model(
             oqparam, sitecol, prefilter=filtersources, in_memory=filtersources)
         assoc = csm.get_rlzs_assoc()
         print assoc.csm_info
         print assoc
         if filtersources:
-            # display information about the size of the hazard curve matrices
-            tup = (len(sitecol),
-                   sum(len(imls) for imls in oqparam.imtls.values() if imls),
-                   len(assoc))
-            size_mb = (tup[0] * tup[1] * tup[2] * 8.) / 1024 / 1024
-            if size_mb:
-                print "sites, levels, keys = %s [~%d MB]" % (tup, size_mb)
+            info = readinput.get_job_info(oqparam, csm, sitecol)
+            for k in sorted(info):
+                print k, info[k]
         if len(assets_by_site):
             print 'assets = %d' % sum(len(assets) for assets in assets_by_site)
     else:

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -46,7 +46,7 @@ def info(name, filtersources=False):
                     oqparam), []
         else:
             sitecol, assets_by_site = None, []
-        print 'Reading and filtering the source model...'
+        print 'Reading the source model...'
         csm = readinput.get_composite_source_model(
             oqparam, sitecol, prefilter=filtersources, in_memory=filtersources)
         assoc = csm.get_rlzs_assoc()


### PR DESCRIPTION
This is useful to know how big is a computation *before* running it. User of OATS may check if the computation is outside the weight limits. Here is an example of usage:

```bash
$ oq-lite info job.ini -f
Reading and filtering the source model...
<CompositionInfo
b1, NSHMP2008US.xml, trt=[0]: 1 realization(s)>
<RlzsAssoc
0,ChiouYoungs2008: ['<0,b1,b3,w=1.0>']>
input_weight 14504
max_realizations 1
n_imts 1
n_levels 19.0
n_sites 1000
output_weight 19000.0
```