### PR TITLE
Added an ID to the VulnerabilityFunction class

### DIFF
--- a/openquake/commonlib/converter.py
+++ b/openquake/commonlib/converter.py
@@ -146,7 +146,8 @@ class Vulnerability(Converter):
 
             # check that we can instantiate a VulnerabilityFunction in risklib
             scientific.VulnerabilityFunction(
-                imt, map(float, imls), map(float, ratios), map(float, coeffs))
+                vf_id, imt, map(float, imls),
+                map(float, ratios), map(float, coeffs))
 
             dvf.lossRatio.text = ' '.join(ratios)
             dvf.coefficientsVariation.text = ' '.join(coeffs)

--- a/openquake/commonlib/riskmodels.py
+++ b/openquake/commonlib/riskmodels.py
@@ -153,7 +153,7 @@ def get_vulnerability_functions(fname):
                      vfun.coefficientsVariation.lineno))
             with context(fname, vfun):
                 vf_dict[imt_str, taxonomy] = scientific.VulnerabilityFunction(
-                    imt_str, imls, loss_ratios, coefficients,
+                    taxonomy, imt_str, imls, loss_ratios, coefficients,
                     vfun['probabilisticDistribution'])
     return vf_dict
 

--- a/openquake/risklib/qa_tests/bcr_test.py
+++ b/openquake/risklib/qa_tests/bcr_test.py
@@ -25,14 +25,14 @@ class BCRTestCase(unittest.TestCase):
     def test_bcr_classical(self):
         vulnerability_function_rm = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'RM', 'PGA',
                 [0.1, 0.2, 0.3, 0.45, 0.6],
                 [0.05, 0.1, 0.2, 0.4, 0.8],
                 [0.5, 0.4, 0.3, 0.2, 0.1], "LN"))
 
         vulnerability_function_rf = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'RF', 'PGA',
                 [0.1, 0.2, 0.3, 0.45, 0.6],
                 [0.035, 0.07, 0.14, 0.28, 0.56],
                 [0.5, 0.4, 0.3, 0.2, 0.1], "LN"))

--- a/openquake/risklib/qa_tests/classical_test.py
+++ b/openquake/risklib/qa_tests/classical_test.py
@@ -43,7 +43,7 @@ class ClassicalTestCase(unittest.TestCase):
     def test_lognormal_distribution(self):
         loss_ratio_curve = scientific.classical(
             scientific.VulnerabilityFunction(
-                'PGA',
+                'VF', 'PGA',
                 [0.1, 0.2, 0.3, 0.45, 0.6],
                 [0.05, 0.1, 0.2, 0.4, 0.8],
                 [0.5, 0.4, 0.3, 0.2, 0.1]),
@@ -84,7 +84,7 @@ class ClassicalTestCase(unittest.TestCase):
     def test_beta_distribution(self):
         loss_ratio_curve = scientific.classical(
             scientific.VulnerabilityFunction(
-                'PGA',
+                'VF', 'PGA',
                 [0.1, 0.2, 0.3, 0.45, 0.6],
                 [0.05, 0.1, 0.2, 0.4, 0.8],
                 [0.5, 0.4, 0.3, 0.2, 0.1],

--- a/openquake/risklib/qa_tests/event_based_test.py
+++ b/openquake/risklib/qa_tests/event_based_test.py
@@ -47,7 +47,7 @@ class EventBasedTestCase(unittest.TestCase):
         # This is a regression test. Data has not been checked
         vf = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'SOME-TAXONOMY', 'PGA',
                 [0.001, 0.2, 0.3, 0.5, 0.7],
                 [0.01, 0.1, 0.2, 0.4, 0.8],
                 [0.01, 0.02, 0.02, 0.01, 0.03]))
@@ -88,7 +88,7 @@ class EventBasedTestCase(unittest.TestCase):
         # This is a regression test. Data has not been checked
         vf = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'SOME-TAXONOMY', 'PGA',
                 [0.001, 0.2, 0.3, 0.5, 0.7],
                 [0.01, 0.1, 0.2, 0.4, 0.8],
                 [0.01, 0.02, 0.02, 0.01, 0.03]))
@@ -127,7 +127,7 @@ class EventBasedTestCase(unittest.TestCase):
         # This is a regression test. Data has not been checked
         vf = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'SOME-TAXONOMY', 'PGA',
                 [0.001, 0.2, 0.3, 0.5, 0.7],
                 [0.01, 0.1, 0.2, 0.4, 0.8],
                 [0.01, 0.02, 0.02, 0.01, 0.03]))
@@ -168,14 +168,14 @@ class EventBasedTestCase(unittest.TestCase):
         epsilons = scientific.make_epsilons([gmf[0]], seed=1, correlation=0)
         vulnerability_function_rm = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'RM', 'PGA',
                 [0.001, 0.2, 0.3, 0.5, 0.7],
                 [0.01, 0.1, 0.2, 0.4, 0.8],
                 [0.0, 0.0, 0.0, 0.0, 0.0]))
 
         vulnerability_function_rc = (
             scientific.VulnerabilityFunction(
-                'PGA',
+                'RC', 'PGA',
                 [0.001, 0.2, 0.3, 0.5, 0.7],
                 [0.0035, 0.07, 0.14, 0.28, 0.56],
                 [0.0, 0.0, 0.0, 0.0, 0.0]))
@@ -212,7 +212,7 @@ class EventBasedTestCase(unittest.TestCase):
 
     def test_insured_loss_mean_based(self):
         vf = scientific.VulnerabilityFunction(
-            'PGA',
+            'VF', 'PGA',
             [0.001, 0.2, 0.3, 0.5, 0.7],
             [0.01, 0.1, 0.2, 0.4, 0.8],
             [0.0, 0.0, 0.0, 0.0, 0.0])

--- a/openquake/risklib/qa_tests/event_based_test.py
+++ b/openquake/risklib/qa_tests/event_based_test.py
@@ -103,7 +103,7 @@ class EventBasedTestCase(unittest.TestCase):
         self.assertAlmostEqual(0.48983614471, first_curve_integral)
 
         wf = workflows.ProbabilisticEventBased(
-            'PGA', 'SOMETAXONOMY',
+            'PGA', 'SOME-TAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
             hazard_investigation_time=50,
@@ -144,7 +144,7 @@ class EventBasedTestCase(unittest.TestCase):
         self.assertAlmostEqual(0.483041416, first_curve_integral)
 
         wf = workflows.ProbabilisticEventBased(
-            'PGA', 'SOMETAXONOMY',
+            'PGA', 'SOME-TAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
             hazard_investigation_time=50,
@@ -237,7 +237,7 @@ class EventBasedTestCase(unittest.TestCase):
             insured_average_losses)
 
         wf = workflows.ProbabilisticEventBased(
-            'PGA', 'SOMETAXONOMY',
+            'PGA', 'SOME-TAXONOMY',
             vulnerability_functions={self.loss_type: vf},
             risk_investigation_time=50,
             hazard_investigation_time=50,

--- a/openquake/risklib/qa_tests/scenario_test.py
+++ b/openquake/risklib/qa_tests/scenario_test.py
@@ -28,7 +28,7 @@ gmv = vectors_from_csv('gmv', THISDIR)
 
 def vf(loss_ratios, covs=(0.0, 0.0, 0.0, 0.0, 0.0)):
     return scientific.VulnerabilityFunction(
-        'PGA', [0.1, 0.2, 0.3, 0.5, 0.7], loss_ratios, covs)
+        'VF', 'PGA', [0.1, 0.2, 0.3, 0.5, 0.7], loss_ratios, covs)
 
 
 class ScenarioTestCase(unittest.TestCase):

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -116,10 +116,10 @@ class VulnerabilityFunction(object):
         :param str distribution_name: The probabilistic distribution
             related to this function.
         """
-        self._check_vulnerability_data(
-            imls, mean_loss_ratios, covs, distribution)
         self.id = vf_id
         self.imt = imt
+        self._check_vulnerability_data(
+            imls, mean_loss_ratios, covs, distribution)
         self.imls = numpy.array(imls)
         self.mean_loss_ratios = numpy.array(mean_loss_ratios)
 
@@ -240,15 +240,16 @@ class VulnerabilityFunction(object):
                 [self.imls[-1], self.imls[0], lambda x: x]))
 
     def __getstate__(self):
-        return (self.imt, self.imls, self.mean_loss_ratios,
+        return (self.id, self.imt, self.imls, self.mean_loss_ratios,
                 self.covs, self.distribution_name)
 
     def __setstate__(self, state):
-        self.imt = state[0]
-        self.imls = state[1]
-        self.mean_loss_ratios = state[2]
-        self.covs = state[3]
-        self.distribution_name = state[4]
+        self.id = state[0]
+        self.imt = state[1]
+        self.imls = state[2]
+        self.mean_loss_ratios = state[3]
+        self.covs = state[4]
+        self.distribution_name = state[5]
         self.init()
 
     def _check_vulnerability_data(self, imls, loss_ratios, covs, distribution):

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -89,7 +89,7 @@ def fine_graining(points, steps):
 
 
 class VulnerabilityFunction(object):
-    def __init__(self, imt, imls, mean_loss_ratios, covs=None,
+    def __init__(self, vf_id, imt, imls, mean_loss_ratios, covs=None,
                  distribution="LN"):
         """
         A wrapper around a probabilistic distribution function
@@ -100,6 +100,7 @@ class VulnerabilityFunction(object):
         fields and epsilons and return a loss matrix with N x R
         elements.
 
+        :param str vf_id: Vulnerability Function ID
         :param str imt: Intensity Measure Type as a string
 
         :param list imls: Intensity Measure Levels for the
@@ -117,6 +118,7 @@ class VulnerabilityFunction(object):
         """
         self._check_vulnerability_data(
             imls, mean_loss_ratios, covs, distribution)
+        self.id = vf_id
         self.imt = imt
         self.imls = numpy.array(imls)
         self.mean_loss_ratios = numpy.array(mean_loss_ratios)
@@ -194,7 +196,7 @@ class VulnerabilityFunction(object):
                 previous_mlr = mlr
 
         return self.__class__(
-            self.imt, imls, mlrs, covs, self.distribution_name)
+            self.id, self.imt, imls, mlrs, covs, self.distribution_name)
 
     def mean_loss_ratios_with_steps(self, steps):
         """
@@ -332,7 +334,7 @@ class VulnerabilityFunction(object):
             [self.imls[-1] + ((self.imls[-1] - self.imls[-2]) / 2)])
 
     def __repr__(self):
-        return '<VulnerabilityFunction(%s)>' % self.imt
+        return '<VulnerabilityFunction(%s, %s)>' % (self.id, self.imt)
 
 
 class FragilityFunctionContinuous(object):

--- a/openquake/risklib/tests/classical_test.py
+++ b/openquake/risklib/tests/classical_test.py
@@ -144,7 +144,7 @@ class ClassicalTestCase(unittest.TestCase):
             [0.0000000, 0.0000000, 0.0000000, 0.0000000, 0.0000000]]
 
         vf = scientific.VulnerabilityFunction(
-            'PGA', self.imls, self.mean_loss_ratios, self.covs, "BT")
+            'VF', 'PGA', self.imls, self.mean_loss_ratios, self.covs, "BT")
 
         loss_ratios, lrem = vf.loss_ratio_exceedance_matrix(5)
         numpy.testing.assert_allclose(
@@ -156,7 +156,7 @@ class ClassicalTestCase(unittest.TestCase):
         loss_ratios = [0.05, 0.08, 0.2, 0.4]
 
         vulnerability_function = scientific.VulnerabilityFunction(
-            'PGA', imls, loss_ratios, covs, "LN")
+            'VF', 'PGA', imls, loss_ratios, covs, "LN")
 
         expected_steps = [0.05, 0.15, 0.3, 0.5, 0.7]
 
@@ -171,7 +171,7 @@ class ClassicalTestCase(unittest.TestCase):
         loss_ratios = [0.05, 0.08, 0.2, 0.4]
 
         vulnerability_function = scientific.VulnerabilityFunction(
-            'PGA', imls, loss_ratios, covs, "LN")
+            'VF', 'PGA', imls, loss_ratios, covs, "LN")
 
         loss_ratio_curve = scientific.classical(
             vulnerability_function, hazard_imls, hazard_curve, 2)

--- a/openquake/risklib/tests/event_based_test.py
+++ b/openquake/risklib/tests/event_based_test.py
@@ -72,7 +72,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
 
     def setUp(self):
         self.vulnerability_function1 = scientific.VulnerabilityFunction(
-            'PGA',
+            'VF1', 'PGA',
             [0.01, 0.04, 0.07, 0.1, 0.12, 0.22, 0.37, 0.52],
             [0.001, 0.022, 0.051, 0.08, 0.1, 0.2, 0.405, 0.7],
             [0.0] * 8, "LN")
@@ -83,7 +83,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         ])
 
         self.vulnerability_function2 = scientific.VulnerabilityFunction(
-            'PGA',
+            'VF2', 'PGA',
             [0.0, 0.04, 0.08, 0.12, 0.16, 0.2, 0.24, 0.28, 0.32, 0.36,
              0.4, 0.44, 0.48, 0.53, 0.57, 0.61, 0.65, 0.69, 0.73, 0.77, 0.81,
              0.85, 0.89, 0.93, 0.97, 1.01, 1.05, 1.09, 1.13, 1.17, 1.21, 1.25,
@@ -151,7 +151,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         """
 
         vf = scientific.VulnerabilityFunction(
-            'PGA',
+            'VF', 'PGA',
             [0.10, 0.30, 0.50, 1.00], [0.05, 0.10, 0.15, 0.30],
             [0.30, 0.30, 0.20, 0.20], "LN")
 
@@ -178,7 +178,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         """
 
         vuln_function = scientific.VulnerabilityFunction(
-            'PGA',
+            'VF', 'PGA',
             [0.10, 0.30, 0.50, 1.00], [0.05, 0.10, 0.15, 0.30],
             [0.30, 0.30, 0.20, 0.20], "LN")
 
@@ -204,7 +204,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         loss_ratios = [0.05, 0.10, 0.15, 0.30]
         covs = [0.30, 0.30, 0.20, 0.20]
         vuln_function = scientific.VulnerabilityFunction(
-            'PGA', imls, loss_ratios, covs, "LN")
+            'VF', 'PGA', imls, loss_ratios, covs, "LN")
 
         gmfs = (1.1, 0.9706, 0.9572, 0.4854, 0.8003,
                 0.1419, 0.4218, 0.9157, 1.05, 0.9595)

--- a/openquake/risklib/tests/scientific_test.py
+++ b/openquake/risklib/tests/scientific_test.py
@@ -86,10 +86,12 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
     COVS_TOO_LONG = [0.3, 0.1, 0.3, 0.0, 0.3, 10, 11]
 
     IMT = 'PGA'
+    ID = 'vf1'
 
     def setUp(self):
         self.test_func = scientific.VulnerabilityFunction(
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD, self.COVS_GOOD)
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
+            self.COVS_GOOD)
 
         epsilons = scientific.make_epsilons(
             numpy.zeros((1, 1)), seed=3, correlation=0)
@@ -103,15 +105,17 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
         #     - IML list ordered improperly
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_BAD, self.LOSS_RATIOS_GOOD, self.COVS_GOOD)
+            self.ID, self.IMT, self.IMLS_BAD, self.LOSS_RATIOS_GOOD,
+            self.COVS_GOOD)
 
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_DUPE, self.LOSS_RATIOS_GOOD, self.COVS_GOOD)
+            self.ID, self.IMT, self.IMLS_DUPE, self.LOSS_RATIOS_GOOD,
+            self.COVS_GOOD)
 
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_BAD_ORDER, self.LOSS_RATIOS_GOOD,
+            self.ID, self.IMT, self.IMLS_BAD_ORDER, self.LOSS_RATIOS_GOOD,
             self.COVS_GOOD)
 
     def test_vuln_func_constructor_raises_on_bad_cov(self):
@@ -122,16 +126,17 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
         #     - CoV list which is longer than the IML list
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD, self.COVS_BAD)
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
+            self.COVS_BAD)
 
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
             self.COVS_TOO_SHORT)
 
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_GOOD,
             self.COVS_TOO_LONG)
 
     def test_vuln_func_constructor_raises_on_bad_loss_ratios(self):
@@ -142,21 +147,21 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
         #     - loss ratio list which is longer than the IML list
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_BAD, self.COVS_GOOD)
-
-        self.assertRaises(
-            AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_TOO_SHORT,
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_BAD,
             self.COVS_GOOD)
 
         self.assertRaises(
             AssertionError, scientific.VulnerabilityFunction,
-            self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_TOO_LONG,
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_TOO_SHORT,
+            self.COVS_GOOD)
+
+        self.assertRaises(
+            AssertionError, scientific.VulnerabilityFunction,
+            self.ID, self.IMT, self.IMLS_GOOD, self.LOSS_RATIOS_TOO_LONG,
             self.COVS_GOOD)
 
     def test_loss_ratio_interp_many_values(self):
-        expected_lrs = numpy.array([0.0161928, 0.07685701,
-                                    4.64095499])
+        expected_lrs = numpy.array([0.0161928, 0.07685701, 4.64095499])
         test_input = [0.005, 0.006, 0.0269]
 
         numpy.testing.assert_allclose(
@@ -196,7 +201,7 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
         # a ValueError.
         with self.assertRaises(ValueError) as ar:
             scientific.VulnerabilityFunction(
-                self.IMT, self.IMLS_GOOD,
+                self.ID, self.IMT, self.IMLS_GOOD,
                 [0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
                 [0.001, 0.002, 0.003, 0.004, 0.005, 0.006],
             )
@@ -213,7 +218,7 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
         # this LR are 0.
         # If LR = 0 and CoV = 0, the PoE will be 0.
         curve = scientific.VulnerabilityFunction(
-            self.IMT,
+            self.ID, self.IMT,
             [0.1, 0.2, 0.3, 0.45, 0.6],  # IMLs
             [0.0, 0.1, 0.2, 0.4, 1.2],   # loss ratios
             [0.0, 0.0, 0.3, 0.2, 0.1],   # CoVs
@@ -249,7 +254,7 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
 class MeanLossTestCase(unittest.TestCase):
     def test_mean_loss(self):
         vf = scientific.VulnerabilityFunction(
-            'PGA', imls=[0.1, 0.2, 0.3, 0.5, 0.7],
+            'VF1', 'PGA', imls=[0.1, 0.2, 0.3, 0.5, 0.7],
             mean_loss_ratios=[0.0035, 0.07, 0.14, 0.28, 0.56],
             covs=[0.1, 0.2, 0.3, 0.4, 0.5])
 
@@ -318,9 +323,9 @@ class VulnerabilityLossRatioStepsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.v1 = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1], [0.5, 0.7], [0, 0], "LN")
+            'V1', self.IMT, [0, 1], [0.5, 0.7], [0, 0], "LN")
         self.v2 = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1, 2], [0.25, 0.5, 0.75], [0, 0, 0], "LN")
+            'V2', self.IMT, [0, 1, 2], [0.25, 0.5, 0.75], [0, 0, 0], "LN")
 
     def test_split_single_interval_with_no_steps_between(self):
         numpy.testing.assert_allclose(
@@ -352,7 +357,7 @@ class VulnerabilityLossRatioStepsTestCase(unittest.TestCase):
 
     def test__evenly_spaced_loss_ratios(self):
         vf = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1, 2, 3, 4], [0.0, 0.1, 0.2, 0.4, 1.2],
+            'VF', self.IMT, [0, 1, 2, 3, 4], [0.0, 0.1, 0.2, 0.4, 1.2],
             [0, 0, 0, 0, 0])
 
         es_lrs = vf.mean_loss_ratios_with_steps(5)
@@ -365,7 +370,7 @@ class VulnerabilityLossRatioStepsTestCase(unittest.TestCase):
         # We expect a 0.0 to be prepended to the LRs before spacing them
 
         vf = scientific.VulnerabilityFunction(
-            self.IMT, [1, 2, 3, 4], [0.1, 0.2, 0.4, 1.2], [0, 0, 0, 0])
+            'VF', self.IMT, [1, 2, 3, 4], [0.1, 0.2, 0.4, 1.2], [0, 0, 0, 0])
         es_lrs = vf.mean_loss_ratios_with_steps(5)
         expected = [0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14, 0.16, 0.18,
                     0.2, 0.24000000000000002, 0.28, 0.32, 0.36, 0.4, 0.56,
@@ -374,14 +379,14 @@ class VulnerabilityLossRatioStepsTestCase(unittest.TestCase):
 
     def test__evenly_spaced_loss_ratios_append_1(self):
         vf = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1], [0.0, 0.5], [0, 0])
+            'VF', self.IMT, [0, 1], [0.0, 0.5], [0, 0])
         es_lrs = vf.mean_loss_ratios_with_steps(2)
         expected = [0.0, 0.25, 0.5, 0.75, 1.0]
         numpy.testing.assert_allclose(es_lrs, expected)
 
     def test_strictly_increasing(self):
         vf = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1, 2, 3], [0.0, 0.5, 0.5, 1], [0, 0, 3, 4])
+            'VF', self.IMT, [0, 1, 2, 3], [0.0, 0.5, 0.5, 1], [0, 0, 3, 4])
         vfs = vf.strictly_increasing()
 
         numpy.testing.assert_allclose([0, 1, 3], vfs.imls)
@@ -391,7 +396,7 @@ class VulnerabilityLossRatioStepsTestCase(unittest.TestCase):
 
     def test_pickle(self):
         vf = scientific.VulnerabilityFunction(
-            self.IMT, [0, 1, 2, 3], [0.0, 0.5, 0.5, 1], [0, 0, 3, 4])
+            'VF', self.IMT, [0, 1, 2, 3], [0.0, 0.5, 0.5, 1], [0, 0, 3, 4])
         pickle.loads(pickle.dumps(vf))
 
 


### PR DESCRIPTION
This is needed in order to be able to serialize as XML a VulnerabilityFunction object.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/644