### PR TITLE
Fixed a bug when a numpy array was passed as first argument to apply_reduce

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug in apply_reduce when the first argument is a numpy array
   * Added a functionality `write_source_model` to serialize sources in XML
 
 python-oq-risklib (0.7.1-0~precise01) precise; urgency=low

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -274,14 +274,15 @@ class TaskManager(object):
         :param weight: function to extract the weight of an item in arg0
         :param key: function to extract the kind of an item in arg0
         """
-        arg0 = task_args[0]
+        arg0 = task_args[0]  # this is assumed to be a sequence
+        num_items = len(arg0)
         args = task_args[1:]
         task_func = getattr(task, 'task_func', task)
         if acc is None:
             acc = AccumDict()
-        if not arg0:
+        if num_items == 0:  # nothing to do
             return acc
-        elif len(arg0) == 1:
+        elif num_items == 1:  # apply the function in the master process
             return agg(acc, task_func(arg0, *args))
         chunks = list(split_in_blocks(
             arg0, concurrent_tasks or 1, weight, key))

--- a/openquake/commonlib/tests/parallel_test.py
+++ b/openquake/commonlib/tests/parallel_test.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy
 from openquake.commonlib import parallel
 
 
@@ -11,7 +12,7 @@ class TaskManagerTestCase(unittest.TestCase):
 
     def test_apply_reduce(self):
         res = parallel.apply_reduce(
-            get_length, (range(10),), concurrent_tasks=3)
+            get_length, (numpy.arange(10),), concurrent_tasks=3)
         self.assertEqual(res, {'n': 10})
         self.assertEqual(map(len, parallel.apply_reduce._chunks), [4, 4, 2])
 


### PR DESCRIPTION
This was reported by Graeme. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/650