### PR TITLE
Store the epsilons matrix in HDF5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * The epsilon_matrix is now saved in HDF5 format
   * Fixed a bug in apply_reduce when the first argument is a numpy array
   * Added a functionality `write_source_model` to serialize sources in XML
 

--- a/openquake/commonlib/calculators/event_based_risk.py
+++ b/openquake/commonlib/calculators/event_based_risk.py
@@ -119,7 +119,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
     pre_calculator = 'event_based_rupture'
     core_func = event_based_risk
 
-    epsilons = datastore.persistent_attribute('/epsilon_matrix')
+    epsilon_matrix = datastore.persistent_attribute('/epsilon_matrix')
     event_loss_asset = datastore.persistent_attribute('event_loss_asset')
     event_loss = datastore.persistent_attribute('event_loss')
     is_stochastic = True
@@ -154,7 +154,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         eps_dict = riskinput.make_eps_dict(
             assets_by_site, num_samples, oq.master_seed, oq.asset_correlation)
         logging.info('Generated %d epsilons', num_samples * len(eps_dict))
-        self.epsilons = numpy.array(
+        self.epsilon_matrix = numpy.array(
             [eps_dict[a['asset_ref']] for a in self.assetcol])
         self.riskinputs = list(self.riskmodel.build_inputs_from_ruptures(
             self.sitecol.complete, all_ruptures, gsims_by_col,

--- a/openquake/commonlib/calculators/event_based_risk.py
+++ b/openquake/commonlib/calculators/event_based_risk.py
@@ -119,6 +119,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
     pre_calculator = 'event_based_rupture'
     core_func = event_based_risk
 
+    epsilons = datastore.persistent_attribute('/epsilon_matrix')
     event_loss_asset = datastore.persistent_attribute('event_loss_asset')
     event_loss = datastore.persistent_attribute('event_loss')
     is_stochastic = True
@@ -153,7 +154,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         eps_dict = riskinput.make_eps_dict(
             assets_by_site, num_samples, oq.master_seed, oq.asset_correlation)
         logging.info('Generated %d epsilons', num_samples * len(eps_dict))
-
+        self.epsilons = numpy.array(
+            [eps_dict[a['asset_ref']] for a in self.assetcol])
         self.riskinputs = list(self.riskmodel.build_inputs_from_ruptures(
             self.sitecol.complete, all_ruptures, gsims_by_col,
             oq.truncation_level, correl_model, eps_dict,

--- a/openquake/commonlib/calculators/scenario_risk.py
+++ b/openquake/commonlib/calculators/scenario_risk.py
@@ -19,6 +19,8 @@
 import os
 import logging
 
+import numpy
+
 from openquake.baselib import general
 from openquake.commonlib import parallel, datastore
 from openquake.commonlib.calculators import base
@@ -93,6 +95,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
     Run a scenario risk calculation
     """
     core_func = scenario_risk
+    epsilon_matrix = datastore.persistent_attribute('/epsilon_matrix')
     losses_by_key = datastore.persistent_attribute('losses_by_key')
     gmf_by_trt_gsim = datastore.persistent_attribute('gmf_by_trt_gsim')
     pre_calculator = 'scenario'
@@ -110,7 +113,8 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         logging.info('Building the epsilons')
         eps_dict = self.make_eps_dict(
             self.oqparam.number_of_ground_motion_fields)
-
+        self.epsilon_matrix = numpy.array(
+            [eps_dict[a['asset_ref']] for a in self.assetcol])
         self.riskinputs = self.build_riskinputs(base.get_gmfs(self), eps_dict)
 
     def post_execute(self, result):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1448932.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/704

You can run a calculation and open the output.hdf5 file, or export it to CSV with the command

```bash
$ oq-lite export -1 /epsilon_matrix
```

