### PR TITLE
Monitor the time spent in filtering/splitting the sources

### DIFF
--- a/openquake/commonlib/calculators/base.py
+++ b/openquake/commonlib/calculators/base.py
@@ -314,7 +314,7 @@ class HazardCalculator(BaseCalculator):
                     'reading composite source model', autoflush=True):
                 self.composite_source_model = (
                     readinput.get_composite_source_model(
-                        self.oqparam, self.sitecol))
+                        self.oqparam, self.sitecol, monitor=self.monitor))
                 self.source_info = self.composite_source_model.source_info
                 self.job_info = readinput.get_job_info(
                     self.oqparam, self.composite_source_model, self.sitecol)


### PR DESCRIPTION
This is a minor improvement.The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/710