### PR TITLE
Restored the oq-lite tiling calculator

### DIFF
--- a/openquake/commonlib/calculators/base.py
+++ b/openquake/commonlib/calculators/base.py
@@ -316,11 +316,12 @@ class HazardCalculator(BaseCalculator):
                     readinput.get_composite_source_model(
                         self.oqparam, self.sitecol if self.prefilter else None,
                         monitor=self.monitor))
-                self.source_info = self.composite_source_model.source_info
-                self.job_info = readinput.get_job_info(
-                    self.oqparam, self.composite_source_model, self.sitecol)
                 # we could manage limits here
                 if self.prefilter:
+                    self.source_info = self.composite_source_model.source_info
+                    self.job_info = readinput.get_job_info(
+                        self.oqparam, self.composite_source_model,
+                        self.sitecol)
                     self.composite_source_model.count_ruptures()
                     self.rlzs_assoc = (self.composite_source_model.
                                        get_rlzs_assoc())

--- a/openquake/commonlib/calculators/base.py
+++ b/openquake/commonlib/calculators/base.py
@@ -314,7 +314,8 @@ class HazardCalculator(BaseCalculator):
                     'reading composite source model', autoflush=True):
                 self.composite_source_model = (
                     readinput.get_composite_source_model(
-                        self.oqparam, self.sitecol, monitor=self.monitor))
+                        self.oqparam, self.sitecol if self.prefilter else None,
+                        monitor=self.monitor))
                 self.source_info = self.composite_source_model.source_info
                 self.job_info = readinput.get_job_info(
                     self.oqparam, self.composite_source_model, self.sitecol)

--- a/openquake/commonlib/calculators/classical.py
+++ b/openquake/commonlib/calculators/classical.py
@@ -189,12 +189,12 @@ def is_effective_trt_model(result_dict, trt_model):
 
 
 @parallel.litetask
-def classical_tiling(calculator, sites, position, tileno, monitor):
+def classical_tiling(calculator, sitecol, position, tileno, monitor):
     """
     :param calculator:
         a ClassicalCalculator instance
-    :param sites:
-        the sites of the current tile
+    :param sitecol:
+        the site collection of the current tile
     :param indices:
         the indices of the sites in the current tile
     :param position:
@@ -204,10 +204,10 @@ def classical_tiling(calculator, sites, position, tileno, monitor):
     :returns:
         a dictionary file name -> full path for each exported file
     """
-    calculator.sitecol = SiteCollection(sites)
+    calculator.sitecol = sitecol
     calculator.tileno = '.%04d' % tileno
     curves_by_trt_gsim = calculator.execute()
-    curves_by_trt_gsim.indices = range(position, position + len(sites))
+    curves_by_trt_gsim.indices = range(position, position + len(sitecol))
     # build the correct realizations from the (reduced) logic tree
     calculator.rlzs_assoc = calculator.composite_source_model.get_rlzs_assoc(
         partial(is_effective_trt_model, curves_by_trt_gsim))
@@ -259,7 +259,8 @@ class ClassicalTilingCalculator(ClassicalCalculator):
         all_args = []
         position = 0
         for (i, tile) in enumerate(self.tiles):
-            all_args.append((calculator, tile, position, i, monitor))
+            all_args.append((calculator, SiteCollection(tile),
+                             position, i, monitor))
             position += len(tile)
         acc = {trt_gsim: zero_curves(len(self.sitecol), oq.imtls)
                for trt_gsim in calculator.rlzs_assoc}

--- a/openquake/commonlib/calculators/classical.py
+++ b/openquake/commonlib/calculators/classical.py
@@ -195,10 +195,10 @@ def classical_tiling(calculator, sitecol, position, tileno, monitor):
         a ClassicalCalculator instance
     :param sitecol:
         the site collection of the current tile
-    :param indices:
-        the indices of the sites in the current tile
     :param position:
         position of the current tile in the full site collection
+    :param tileno:
+        the tile ordinal
     :param monitor:
         a monitor instance
     :returns:

--- a/openquake/commonlib/calculators/classical.py
+++ b/openquake/commonlib/calculators/classical.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import numpy
 import logging
 import operator
@@ -30,7 +29,7 @@ from openquake.hazardlib.calc.filters import source_site_distance_filter, \
     rupture_site_distance_filter
 from openquake.risklib import scientific
 from openquake.commonlib import parallel, datastore
-from openquake.baselib.general import AccumDict, split_in_blocks, groupby
+from openquake.baselib.general import AccumDict, split_in_blocks
 
 from openquake.commonlib.calculators import base, calc
 
@@ -190,14 +189,16 @@ def is_effective_trt_model(result_dict, trt_model):
 
 
 @parallel.litetask
-def classical_tiling(calculator, sitecol, tileno, monitor):
+def classical_tiling(calculator, sitecol, site_ids, tileno, monitor):
     """
     :param calculator:
         a ClassicalCalculator instance
     :param sitecol:
-        a SiteCollection instance
+        the site collection of the current tile
+    :param site_ids:
+        the indices of the sites in the current tile
     :param tileno:
-        the number of the current tile
+        the ordinal of the current tile
     :param monitor:
         a monitor instance
     :returns:
@@ -205,16 +206,23 @@ def classical_tiling(calculator, sitecol, tileno, monitor):
     """
     calculator.sitecol = sitecol
     calculator.tileno = '.%04d' % tileno
-    result = calculator.execute()
+    curves_by_trt_gsim = calculator.execute()
+    curves_by_trt_gsim.site_ids = site_ids
     # build the correct realizations from the (reduced) logic tree
     calculator.rlzs_assoc = calculator.composite_source_model.get_rlzs_assoc(
-        partial(is_effective_trt_model, result))
+        partial(is_effective_trt_model, curves_by_trt_gsim))
     n_levels = sum(len(imls) for imls in calculator.oqparam.imtls.itervalues())
-    tup = len(calculator.sitecol), n_levels, len(calculator.rlzs_assoc)
-    logging.info('Processed tile %d, (sites, levels, keys)=%s', tileno, tup)
-    # export the calculator outputs
-    saved = calculator.post_execute(result)
-    return saved
+    tup = (len(calculator.sitecol), n_levels, len(calculator.rlzs_assoc),
+           len(calculator.rlzs_assoc.realizations))
+    logging.info('Processed tile %d, (sites, levels, keys, rlzs)=%s',
+                 tileno, tup)
+    return curves_by_trt_gsim
+
+
+def agg_curves_by_trt_gsim(acc, curves):
+    for trt_gsim in curves:
+        acc[trt_gsim][curves.site_ids] = curves[trt_gsim]
+    return acc
 
 
 @base.calculators.add('classical_tiling')
@@ -223,50 +231,31 @@ class ClassicalTilingCalculator(ClassicalCalculator):
     Classical Tiling calculator
     """
     prefilter = False
-    pathname_by_fname = datastore.persistent_attribute('pathname_by_fname')
 
     def execute(self):
         """
         Split the computation by tiles which are run in parallel.
         """
         monitor = self.monitor(self.core_func.__name__)
-        monitor.oqparam = self.oqparam
-        self.tiles = map(SiteCollection, split_in_blocks(
-            self.sitecol, self.oqparam.concurrent_tasks or 1))
-        self.oqparam.concurrent_tasks = 0
+        monitor.oqparam = oq = self.oqparam
+        self.tiles = split_in_blocks(
+            range(len(self.sitecol)), self.oqparam.concurrent_tasks or 1)
+        oq.concurrent_tasks = 0
         calculator = ClassicalCalculator(
             self.oqparam, monitor, persistent=False)
         calculator.composite_source_model = self.composite_source_model
-        calculator.rlzs_assoc = self.composite_source_model.get_rlzs_assoc(
+        rlzs_assoc = self.composite_source_model.get_rlzs_assoc(
             lambda tm: True)  # build the full logic tree
-        all_args = [(calculator, tile, i, monitor)
-                    for (i, tile) in enumerate(self.tiles)]
-        return parallel.starmap(classical_tiling, all_args).reduce()
+        self.rlzs_assoc = calculator.rlzs_assoc = rlzs_assoc
 
-    def post_execute(self, result):
-        """
-        Merge together the exported files for each tile.
-
-        :param result: a dictionary key -> exported filename
-        """
-        self.pathname_by_fname = result
-        # group files by name; for instance the file names
-        # ['quantile_curve-0.1.csv.0000', 'quantile_curve-0.1.csv.0001',
-        # 'hazard_map-mean.csv.0000', 'hazard_map-mean.csv.0001']
-        # are grouped in the dictionary
-        # {'quantile_curve-0.1.csv': ['quantile_curve-0.1.csv.0000',
-        #                             'quantile_curve-0.1.csv.0001'],
-        # 'hazard_map-mean.csv': ['hazard_map-mean.csv.0000',
-        #                         'hazard_map-mean.csv.0001'],
-        # }
-        dic = groupby((fname for fname in result.itervalues()),
-                      lambda fname: fname.rsplit('.', 1)[0])
-        # merge together files coming from different tiles in order
-        d = {}
-        for fname in dic:
-            with open(fname, 'w') as f:
-                for tilename in sorted(dic[fname]):
-                    f.write(open(tilename).read())
-                    os.remove(tilename)
-            d[os.path.basename(fname)] = fname
-        return d
+        # parallelization
+        all_args = []
+        for (i, tile) in enumerate(self.tiles):
+            siteids = numpy.array(list(tile))
+            sites = numpy.array(list(self.sitecol))[siteids]
+            sitecol = SiteCollection(sites)
+            all_args.append((calculator, sitecol, siteids, i, monitor))
+        acc = {trt_gsim: zero_curves(len(self.sitecol), oq.imtls)
+               for trt_gsim in calculator.rlzs_assoc}
+        return parallel.starmap(classical_tiling, all_args).reduce(
+            agg_curves_by_trt_gsim, acc)

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -159,7 +159,7 @@ class Pickled(object):
 
     def __repr__(self):
         """String representation of the pickled object"""
-        return '<Pickled %s>' % (self.clsname, humansize(len(self)))
+        return '<Pickled %s %s>' % (self.clsname, humansize(len(self)))
 
     def __len__(self):
         """Length of the pickled bytestring"""

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -56,7 +56,7 @@ else:  # Ubuntu 12.04
         return proc.get_memory_info()
 
 
-from openquake.baselib.general import split_in_blocks, AccumDict
+from openquake.baselib.general import split_in_blocks, AccumDict, humansize
 
 
 executor = ProcessPoolExecutor()
@@ -64,9 +64,6 @@ executor = ProcessPoolExecutor()
 # cores; it is a heuristic number to get a decent distribution of the
 # load; it has no more significance than that
 executor.num_tasks_hint = executor._max_workers * 4
-
-
-ONE_MB = 1024 * 1024
 
 
 def no_distribute():
@@ -162,7 +159,7 @@ class Pickled(object):
 
     def __repr__(self):
         """String representation of the pickled object"""
-        return '<Pickled %s %dK>' % (self.clsname, len(self) / 1024)
+        return '<Pickled %s>' % (self.clsname, humansize(len(self)))
 
     def __len__(self):
         """Length of the pickled bytestring"""
@@ -371,9 +368,9 @@ class TaskManager(object):
         if no_distribute():
             agg_result = reduce(agg_and_percent, self.results, acc)
         else:
-            self.progress('Sent %dM of data', self.sent // ONE_MB)
+            self.progress('Sent %s of data', humansize(self.sent))
             agg_result = self.aggregate_result_set(agg_and_percent, acc)
-            self.progress('Received %dM of data', self.received // ONE_MB)
+            self.progress('Received %s of data', humansize(self.received))
         self.results = []
         return agg_result
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -472,7 +472,7 @@ def get_composite_source_model(
             trt_id += 1
         smodels.append(source_model)
     csm = source.CompositeSourceModel(source_model_lt, smodels)
-    if in_memory:
+    if in_memory and sitecol is not None:
         seqtime, partime = processor.process(csm)
         monitor.write(['sequential filtering/splitting', str(seqtime), '0'])
         monitor.write(['parallel filtering/splitting', str(partime), '0'])

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -472,7 +472,7 @@ def get_composite_source_model(
             trt_id += 1
         smodels.append(source_model)
     csm = source.CompositeSourceModel(source_model_lt, smodels)
-    if in_memory and sitecol is not None:
+    if in_memory:
         seqtime, partime = processor.process(csm)
         monitor.write(['sequential filtering/splitting', str(seqtime), '0'])
         monitor.write(['parallel filtering/splitting', str(partime), '0'])

--- a/openquake/commonlib/tests/calculators/__init__.py
+++ b/openquake/commonlib/tests/calculators/__init__.py
@@ -91,19 +91,19 @@ class CalculatorTestCase(unittest.TestCase):
         """
         expected = os.path.join(self.testdir, fname1)
         actual = os.path.join(self.calc.oqparam.export_dir, fname2)
-        expected_content = ''.join(
-            make_comparable(open(expected).readlines()))
-        actual_content = ''.join(make_comparable(open(actual).readlines()))
+        expected_lines = make_comparable(open(expected))
+        actual_lines = make_comparable(open(actual))
         try:
-            if delta:
-                self.practicallyEqual(expected_content, actual_content, delta)
-            else:
-                self.assertEqual(expected_content, actual_content)
+            for exp, got in zip(expected_lines, actual_lines):
+                if delta:
+                    self.practicallyEqual(exp, got, delta)
+                else:
+                    self.assertEqual(exp, got)
         except AssertionError:
             if self.OVERWRITE_EXPECTED:
                 # use this path when the expected outputs have changed
                 # for a good reason
-                open(expected, 'w').write(actual_content)
+                open(expected, 'w').write(''.join(actual_lines))
             else:
                 # normally raise an exception
                 raise DifferentFiles('%s %s' % (expected, actual))

--- a/openquake/commonlib/tests/calculators/classical_tiling_test.py
+++ b/openquake/commonlib/tests/calculators/classical_tiling_test.py
@@ -1,4 +1,3 @@
-import unittest
 from nose.plugins.attrib import attr
 from openquake.commonlib.tests.calculators import CalculatorTestCase
 from openquake.qa_tests_data.classical_tiling import case_1
@@ -7,22 +6,24 @@ from openquake.qa_tests_data.classical_tiling import case_1
 class ClassicalTestCase(CalculatorTestCase):
     @attr('qa', 'hazard', 'classical_tiling')
     def test_case_1(self):
-        raise unittest.SkipTest  # temporarily skipped
         out = self.run_calc(case_1.__file__, 'job.ini', exports='csv')
         expected = [
             'hazard_curve-mean.csv',
-            'hazard_uhs-mean.csv',
             'hazard_curve-smltp_b1-gsimltp_b1.csv',
-            'hazard_uhs-smltp_b1-gsimltp_b1.csv',
             'hazard_curve-smltp_b1-gsimltp_b2.csv',
-            'hazard_uhs-smltp_b1-gsimltp_b2.csv',
-            'hazard_map-mean.csv',
             'quantile_curve-0.1.csv',
+            'hazard_map-mean.csv',
             'hazard_map-smltp_b1-gsimltp_b1.csv',
-            'quantile_map-0.1.csv',
             'hazard_map-smltp_b1-gsimltp_b2.csv',
+            'quantile_map-0.1.csv',
+            'hazard_uhs-mean.csv',
+            'hazard_uhs-smltp_b1-gsimltp_b1.csv',
+            'hazard_uhs-smltp_b1-gsimltp_b2.csv',
             'quantile_uhs-0.1.csv',
         ]
-        out = self.run_calc(case_1.__file__, 'job.ini', exports='csv')
-        for fname in expected:
-            self.assertEqualFiles('expected/%s' % fname, out[fname])
+        got = (out['/hcurves', 'csv'] +
+               out.get(('/hmaps', 'csv'), []) +
+               out.get(('/uhs', 'csv'), []))
+        self.assertEqual(len(expected), len(got))
+        for fname, actual in zip(expected, got):
+            self.assertEqualFiles('expected/%s' % fname, actual, delta=1E-6)


### PR DESCRIPTION
I have restored a test that was temporarily skipped and changed the calculator so that the workers do not need access to the file system, so that https://bugs.launchpad.net/oq-engine/+bug/1400041 is closed, at least in principle (then we will need to optimize for large calculations for sure).
Tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/721.
