### PR TITLE
Generated the documentation for the datastore

### DIFF
--- a/docs/openquake.commonlib.rst
+++ b/docs/openquake.commonlib.rst
@@ -25,6 +25,14 @@ commonlib Package
     :undoc-members:
     :show-inheritance:
 
+:mod:`datastore` Module
+------------------------
+
+.. automodule:: openquake.commonlib.datastore
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`hazard_writers` Module
 ----------------------------
 


### PR DESCRIPTION
This was missing. The documentation builds: https://ci.openquake.org/job/zdevel_oq-risklib/722