### PR TITLE
It is now possible to set concurrent_tasks from the job.ini file

### DIFF
--- a/demos/AreaSourceClassicalPSHA/job.ini
+++ b/demos/AreaSourceClassicalPSHA/job.ini
@@ -2,6 +2,7 @@
 
 description = Classical PSHA using Area Source
 calculation_mode = classical
+concurrent_tasks = 10
 random_seed = 23
 
 [geometry]

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -20,11 +20,10 @@ import logging
 
 from openquake.baselib import performance
 from openquake.commonlib import sap, readinput, valid
-from openquake.commonlib.parallel import executor
 from openquake.commonlib.calculators import base
 
 
-def run(job_ini, concurrent_tasks=executor.num_tasks_hint,
+def run(job_ini, concurrent_tasks=None,
         loglevel='info', hc=None, exports=''):
     """
     Run a calculation. Optionally, set the number of concurrent_tasks
@@ -32,7 +31,8 @@ def run(job_ini, concurrent_tasks=executor.num_tasks_hint,
     """
     logging.basicConfig(level=getattr(logging, loglevel.upper()))
     oqparam = readinput.get_oqparam(job_ini)
-    oqparam.concurrent_tasks = concurrent_tasks
+    if concurrent_tasks is not None:
+        oqparam.concurrent_tasks = concurrent_tasks
     oqparam.hazard_calculation_id = hc
     oqparam.exports = exports
     monitor = performance.Monitor('total', measuremem=True)


### PR DESCRIPTION
This is the oq-lite part of https://bugs.launchpad.net/oq-engine/+bug/1463801.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/730