### PR TITLE
Fixed `show info -d` for the case of sampling

### DIFF
--- a/openquake/commonlib/calculators/base.py
+++ b/openquake/commonlib/calculators/base.py
@@ -323,6 +323,13 @@ class HazardCalculator(BaseCalculator):
                 self.composite_source_model.count_ruptures()
                 self.rlzs_assoc = self.composite_source_model.get_rlzs_assoc()
 
+                logging.info(
+                    'Total weight of the sources=%s',
+                    self.job_info['input_weight'])
+                logging.info(
+                    'Expected output size=%s',
+                    self.job_info['output_weight'])
+
 
 class RiskCalculator(HazardCalculator):
     """

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -129,7 +129,8 @@ def info(name, filtersources=False, weightsources=False, datatransfer=False):
             calc.pre_execute()
             n_tasks, to_send_forward, to_send_back = data_transfer(calc)
             _print_info(calc.rlzs_assoc, oqparam,
-                        calc.composite_source_model, calc.sitecol)
+                        calc.composite_source_model, calc.sitecol,
+                        weightsources=True)
             print('Number of tasks to be generated: %d' % n_tasks)
             print('Estimated data to send forward: %s' %
                   humansize(to_send_forward))

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -132,9 +132,9 @@ def info(name, filtersources=False, weightsources=False, datatransfer=False):
                         calc.composite_source_model, calc.sitecol,
                         weightsources=True)
             print('Number of tasks to be generated: %d' % n_tasks)
-            print('Estimated data to send forward: %s' %
+            print('Estimated data to be sent forward: %s' %
                   humansize(to_send_forward))
-            print('Estimated data to send back: %s' %
+            print('Estimated data to be sent back: %s' %
                   humansize(to_send_back))
         else:
             _info(name, filtersources, weightsources)

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -57,6 +57,21 @@ def data_transfer(calc):
     return n_tasks, to_send_forward, to_send_back
 
 
+def _print_info(assoc, oqparam, csm, sitecol, info=True):
+    print(assoc.csm_info)
+    print('See https://github.com/gem/oq-risklib/blob/master/docs/'
+          'effective-realizations.rst for an explanation')
+    print(assoc)
+    if info:
+        info = readinput.get_job_info(oqparam, csm, sitecol)
+        info['n_sources'] = csm.get_num_sources()
+        info['c_matrix'] = humansize(
+            info['n_sites'] * info['n_levels'] *
+            info['n_imts'] * len(assoc) * 8)
+        for k in sorted(info):
+            print(k, info[k])
+
+
 # the documentation about how to use this feature can be found
 # in the file effective-realizations.rst
 def _info(name, filtersources, weightsources):
@@ -88,18 +103,8 @@ def _info(name, filtersources, weightsources):
                 sp = source.BaseSourceProcessor  # do nothing
             csm = readinput.get_composite_source_model(oqparam, sitecol, sp)
             assoc = csm.get_rlzs_assoc()
-            print(assoc.csm_info)
-            print('See https://github.com/gem/oq-risklib/blob/master/docs/'
-                  'effective-realizations.rst for an explanation')
-            print(assoc)
-            if filtersources or weightsources:
-                info = readinput.get_job_info(oqparam, csm, sitecol)
-                info['n_sources'] = csm.get_num_sources()
-                info['c_matrix'] = humansize(
-                    info['n_sites'] * info['n_levels'] *
-                    info['n_imts'] * len(assoc) * 8)
-                for k in sorted(info):
-                    print(k, info[k])
+            _print_info(assoc, oqparam, csm, sitecol,
+                        filtersources or weightsources)
         if len(assets_by_site):
             print('assets = %d' %
                   sum(len(assets) for assets in assets_by_site))
@@ -119,6 +124,8 @@ def info(name, filtersources=False, weightsources=False, datatransfer=False):
             calc = base.calculators(oqparam)
             calc.pre_execute()
             n_tasks, to_send_forward, to_send_back = data_transfer(calc)
+            _print_info(calc.rlzs_assoc, oqparam,
+                        calc.composite_source_model, calc.sitecol)
             print('Number of tasks to be generated: %d' % n_tasks)
             print('Estimated data to send forward: %s' %
                   humansize(to_send_forward))

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -57,19 +57,23 @@ def data_transfer(calc):
     return n_tasks, to_send_forward, to_send_back
 
 
-def _print_info(assoc, oqparam, csm, sitecol, info=True):
+def _print_info(assoc, oqparam, csm, sitecol,
+                filtersources=True, weightsources=True):
     print(assoc.csm_info)
     print('See https://github.com/gem/oq-risklib/blob/master/docs/'
           'effective-realizations.rst for an explanation')
     print(assoc)
-    if info:
+    if filtersources or weightsources:
         info = readinput.get_job_info(oqparam, csm, sitecol)
         info['n_sources'] = csm.get_num_sources()
         info['c_matrix'] = humansize(
             info['n_sites'] * info['n_levels'] *
             info['n_imts'] * len(assoc) * 8)
         for k in sorted(info):
-            print(k, info[k])
+            if k == 'input_weight' and not weightsources:
+                pass
+            else:
+                print(k, info[k])
 
 
 # the documentation about how to use this feature can be found
@@ -104,7 +108,7 @@ def _info(name, filtersources, weightsources):
             csm = readinput.get_composite_source_model(oqparam, sitecol, sp)
             assoc = csm.get_rlzs_assoc()
             _print_info(assoc, oqparam, csm, sitecol,
-                        filtersources or weightsources)
+                        filtersources, weightsources)
         if len(assets_by_site):
             print('assets = %d' %
                   sum(len(assets) for assets in assets_by_site))

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from openquake.baselib import performance
+from openquake.baselib import performance, general
 from openquake.commonlib import sap, readinput, valid
 from openquake.commonlib.calculators import base
 
@@ -43,7 +43,7 @@ def run(job_ini, concurrent_tasks=None,
     logging.info('See the output with hdfview %s/output.hdf5',
                  calc.datastore.calc_dir)
     logging.info('Total time spent: %s s', monitor.duration)
-    logging.info('Memory allocated: %s M', monitor.mem / 1024. / 1024.)
+    logging.info('Memory allocated: %s', general.humansize(monitor.mem))
     monitor.flush()
 
 parser = sap.Parser(run)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -533,8 +533,6 @@ def get_job_info(oqparam, source_models, sitecol):
     else:
         output_weight *= n_levels
 
-    logging.info('Total weight of the sources=%s', input_weight)
-    logging.info('Expected output size=%s', output_weight)
     return dict(input_weight=input_weight, output_weight=output_weight,
                 n_imts=n_imts, n_levels=n_levels, n_sites=n_sites,
                 max_realizations=max_realizations)

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -72,7 +72,9 @@ output_weight 29.0'''
         path = os.path.join(DATADIR, 'frenchbug.zip')
         with Print.patch() as p:
             info(path, datatransfer=True)
-        self.assertIn('Number of tasks to be generated: 14', str(p))
+        got = str(p)
+        self.assertIn('RlzsAssoc', got)
+        self.assertIn('Number of tasks to be generated: 14', got)
 
 
 class ReduceTestCase(unittest.TestCase):

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -45,7 +45,6 @@ See https://github.com/gem/oq-risklib/blob/master/docs/effective-realizations.rs
             info(path, filtersources=True)
         exp = self.EXPECTED + '''
 c_matrix 232 B
-input_weight 1
 max_realizations 1
 n_imts 1
 n_levels 29.0


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1465615.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/738
