### PR TITLE
Added a facility to create dataset directly from the datastore

### DIFF
--- a/openquake/commonlib/calculators/ebr.py
+++ b/openquake/commonlib/calculators/ebr.py
@@ -136,16 +136,16 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         loss_types = self.riskmodel.get_loss_types()
         self.L = len(loss_types)
         self.R = len(self.rlzs_assoc.realizations)
-        for loss_type in loss_types:
-            for rlz in self.rlzs_assoc.realizations:
-                key = '/%s/%s' % (loss_type, rlz.uid)
-                self.datastore.hdf5.create_dataset(
-                    '/event_loss_table-rlzs' + key, (0,), elt_dt,
-                    chunks=True, maxshape=(None,))
-                if oq.insured_losses:
-                    self.datastore.hdf5.create_dataset(
-                        '/insured_loss_table-rlzs' + key, (0,), elt_dt,
-                        chunks=True, maxshape=(None,))
+        outs = ['/event_loss_table-rlzs']
+        if oq.insured_losses:
+            outs.append('/insured_loss_table-rlzs')
+        self.datasets = {}
+        for o, out in enumerate(outs):
+            for l, loss_type in enumerate(loss_types):
+                for r, rlz in enumerate(self.rlzs_assoc.realizations):
+                    key = '/%s/%s' % (loss_type, rlz.uid)
+                    dset = self.datastore.create_dset(out + key, elt_dt)
+                    self.datasets[o, l, r] = dset
 
     def execute(self):
         """
@@ -184,32 +184,14 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         :param result:
             a numpy array of shape (O, L, R) containing lists of arrays
         """
-        pos = cube(self.monitor.num_outputs, self.L, self.R, int)
         saved_mb = 0
-        rlzs = self.rlzs_assoc.realizations
-        loss_types = self.riskmodel.get_loss_types()
         with self.monitor('saving loss table',
                           autoflush=True, measuremem=True):
-            for (i, l, r), arrays in numpy.ndenumerate(result):
+            for idx, arrays in numpy.ndenumerate(result):
                 if not arrays:  # empty list
                     continue
-                lt = loss_types[l]
-                uid = rlzs[r].uid
-                n = pos[i, l, r]
-                if i == 0:
-                    elt = self.event_loss_table['%s/%s' % (lt, uid)]
-                elif self.oqparam.insured_losses:
-                    elt = self.insured_loss_table['%s/%s' % (lt, uid)]
-                else:
-                    continue
                 losses = numpy.concatenate(arrays)
-
-                # appending rows to the event loss table
-                n1 = n + len(losses)
-                elt.resize((n1,))
-                saved_mb += losses.nbytes
-                elt[n:n1] = losses
-                pos[i, l, r] = n1  # update position in the elt
+                self.datasets[idx].extend(losses)
                 self.datastore.hdf5.flush()
+                saved_mb += losses.nbytes
             logging.info('Saved %s of data', humansize(saved_mb))
-        return {}

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -77,8 +77,7 @@ def get_last_calc_id(datadir=DATADIR):
 
 class Hdf5Dataset(object):
     """
-    Little wrapper around a one-dimensional HDF5 dataset which can grown
-    via the `extend` method.
+    Little wrapper around a one-dimensional HDF5 dataset.
 
     :param hdf5: a h5py.File object
     :param key: an hdf5 key string
@@ -161,7 +160,11 @@ class DataStore(collections.MutableMapping):
 
     def create_dset(self, key, dtype, size=None):
         """
-        Create a one-dimensional extend-able HDF5 dataset
+        Create a one-dimensional HDF5 dataset.
+
+        :param key: a string starting with '/'
+        :param dtype: dtype of the dataset (usually composite)
+        :param size: size of the dataset (if None, the dataset is extendable)
         """
         assert key.startswith('/'), key
         return Hdf5Dataset(self.hdf5, key, dtype, size)

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -85,7 +85,7 @@ class Hdf5Dataset(object):
     :param dtype: dtype of the dataset (usually composite)
     :param size: size of the dataset (if None, the dataset is extendable)
     """
-    def __init__(self, hdf5, key, dtype, size=None):
+    def __init__(self, hdf5, key, dtype, size):
         self.hdf5 = hdf5
         self.key = key
         self.dtype = dtype
@@ -159,12 +159,12 @@ class DataStore(collections.MutableMapping):
         mode = 'r+' if os.path.exists(self.hdf5path) else 'w'
         self.hdf5 = h5py.File(self.hdf5path, mode, libver='latest')
 
-    def create_dset(self, key, dtype):
+    def create_dset(self, key, dtype, size=None):
         """
         Create a one-dimensional extend-able HDF5 dataset
         """
         assert key.startswith('/'), key
-        return Hdf5Dataset(self.hdf5, key, dtype)
+        return Hdf5Dataset(self.hdf5, key, dtype, size)
 
     def path(self, key):
         """


### PR DESCRIPTION
The Hdf5Dataset clas is wrapping the resize logic of HDF5 datasets, which is a bit annoying. In particular it manages the position bookkeeping for extendable datasets. The tests are running here:
https://ci.openquake.org/job/zdevel_oq-risklib/741