### PR TITLE
Recognize negative calculation IDs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Negative calculations IDs are recognized in the oq-lite commands
   * The GMFs are now saved in the HDF5 file
   * Added vulnerability functions with Probability Mass Function
   * oq-lite has now a `reduce` command to reduce large computations

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -19,7 +19,7 @@
 import logging
 
 from openquake.baselib import performance, general
-from openquake.commonlib import sap, readinput, valid
+from openquake.commonlib import sap, readinput, valid, datastore
 from openquake.commonlib.calculators import base
 
 
@@ -33,6 +33,13 @@ def run(job_ini, concurrent_tasks=None,
     oqparam = readinput.get_oqparam(job_ini)
     if concurrent_tasks is not None:
         oqparam.concurrent_tasks = concurrent_tasks
+    if hc and hc < 0:  # interpret negative calculation ids
+        calc_ids = datastore.get_calc_ids()
+        try:
+            hc = calc_ids[hc]
+        except IndexError:
+            raise SystemExit('There are %d old calculations, cannot '
+                             'retrieve the %s' % (len(calc_ids), hc))
     oqparam.hazard_calculation_id = hc
     oqparam.exports = exports
     monitor = performance.Monitor('total', measuremem=True)

--- a/packager.sh
+++ b/packager.sh
@@ -422,7 +422,8 @@ _pkgtest_innervm_run () {
         # run selected risk demos
         ssh $lxc_ip "set -e; cd /usr/share/doc/python-oq-risklib/examples/demos
         echo 'running ClassicalPSHA...'
-        oq-lite run ClassicalPSHA/job_hazard.ini,ClassicalPSHA/job_risk.ini
+        oq-lite run ClassicalPSHA/job_hazard.ini
+        oq-lite run ClassicalPSHA/job_risk.ini --hc -1
         echo 'running ScenarioDamage...'
         oq-lite run ScenarioDamage/job_hazard.ini,ScenarioDamage/job_risk.ini
         echo 'running ProbabilisticEventBased...'


### PR DESCRIPTION
Now you can do

```bash
oq-lite run job_hazard.ini
oq-lite run job_risk.ini --hc -1
```

See https://ci.openquake.org/job/zdevel_oq-risklib/760/console