### PR TITLE
Added a way to disable parallelism in SourceFilterSplitter

### DIFF
--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -288,8 +288,8 @@ class TaskManager(object):
             for chunk in chunks:
                 acc = agg(acc, task_func(chunk, *args))
             return acc
-        tm = cls.starmap(task, [(chunk,) + args for chunk in chunks], name)
-        return tm.reduce(agg, acc)
+        self = cls.starmap(task, [(chunk,) + args for chunk in chunks], name)
+        return self.reduce(agg, acc)
 
     def __init__(self, oqtask, name=None):
         self.oqtask = oqtask
@@ -298,6 +298,7 @@ class TaskManager(object):
         self.results = []
         self.sent = 0
         self.received = 0
+        self.no_distribute = no_distribute()
 
     def submit(self, *args):
         """
@@ -308,7 +309,7 @@ class TaskManager(object):
         """
         check_mem_usage()
         # log a warning if too much memory is used
-        if no_distribute():
+        if self.no_distribute:
             res = safely_call(self.task_func, args)
         else:
             piks = pickle_sequence(args)
@@ -365,7 +366,7 @@ class TaskManager(object):
             log_percent.next()
             return res
 
-        if no_distribute():
+        if self.no_distribute:
             agg_result = reduce(agg_and_percent, self.results, acc)
         else:
             self.progress('Sent %s of data', humansize(self.sent))

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -782,7 +782,7 @@ class SourceFilter(BaseSourceProcessor):
                        info.weight_time, info.split_time))
         return acc + {info.trt_model_id: info.sources}
 
-    def process(self, csm):
+    def process(self, csm, dummy=None):
         """
         :param csm: a CompositeSourceModel instance
         :returns: the times spent in sequential and parallel processing

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import mock
 import time
 import logging
 import operator
@@ -846,7 +847,7 @@ class SourceFilterSplitter(SourceFilterWeighter):
     :param maxdist: maximum distance for the filtering
     :param area_source_discretization: area source discretization
     """
-    def process(self, csm):
+    def process(self, csm, no_distribute=False):
         """
         :param csm: a CompositeSourceModel instance
         :returns: the times spent in sequential and parallel processing
@@ -865,14 +866,14 @@ class SourceFilterSplitter(SourceFilterWeighter):
         # start multicore processing
         if slow_sources:
             t0 = time.time()
-            logging.warn('Parallel processing of %d sources...',
-                         len(slow_sources))
-            ss = parallel.TaskManager.starmap(filter_and_split, slow_sources)
+            logging.warn('Processing %d slow sources...', len(slow_sources))
+            with mock.patch(parallel.no_distribute, lambda: no_distribute):
+                ss = parallel.TaskManager.starmap(
+                    filter_and_split, slow_sources)
 
         # single core processing
         if fast_sources:
-            logging.info('Sequential processing of %d sources...',
-                         len(fast_sources))
+            logging.info('Processing %d fast sources...', len(fast_sources))
             t1 = time.time()
             sources_by_trt += reduce(
                 self.agg_source_info,

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -850,6 +850,7 @@ class SourceFilterSplitter(SourceFilterWeighter):
     def process(self, csm, no_distribute=False):
         """
         :param csm: a CompositeSourceModel instance
+        :param no_distribute: flag to disable parallel processing
         :returns: the times spent in sequential and parallel processing
         """
         sources = csm.get_sources()

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -867,7 +867,8 @@ class SourceFilterSplitter(SourceFilterWeighter):
         if slow_sources:
             t0 = time.time()
             logging.warn('Processing %d slow sources...', len(slow_sources))
-            with mock.patch(parallel.no_distribute, lambda: no_distribute):
+            with mock.patch.object(
+                    parallel, 'no_distribute', lambda: no_distribute):
                 ss = parallel.TaskManager.starmap(
                     filter_and_split, slow_sources)
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1468790.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/773