### PR TITLE
debian/control: add python-mock to the dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: http://github.com/gem/oq-risklib
 
 Package: python-oq-risklib
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.15.0-0~), python-h5py
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.15.0-0~), python-h5py, python-mock
 Provides: python-oq-commonlib
 Conflicts: python-oq-commonlib
 Replaces: python-oq-commonlib


### PR DESCRIPTION
Fixes https://ci.openquake.org/job/master_oq-risklib/1385/ failure