### PR TITLE
setuptools is now required even after the build

### DIFF
--- a/bin/oq-lite
+++ b/bin/oq-lite
@@ -1,0 +1,1 @@
+../openquake/commonlib/commands/__main__.py

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-oq-risklib
 Section: python
 Priority: extra
 Maintainer: Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
-Build-Depends: debhelper (>= 7.0.50~), python (>=2.6), python-setuptools, python-nose, python-coverage, quilt, python-mock
+Build-Depends: debhelper (>= 7.0.50~), python (>=2.6), python-nose, python-coverage, quilt, python-mock
 Standards-Version: 3.9.3
 Homepage: http://github.com/gem/oq-risklib
 #Vcs-Git: git://git.debian.org/collab-maint/python-dateutil.git
@@ -10,7 +10,7 @@ Homepage: http://github.com/gem/oq-risklib
 
 Package: python-oq-risklib
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.15.0-0~), python-h5py, python-mock
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-lxml, python-psutil, python-concurrent.futures, python-oq-hazardlib (>= 0.15.0-0~), python-h5py, python-mock, python-setuptools
 Provides: python-oq-commonlib
 Conflicts: python-oq-commonlib
 Replaces: python-oq-commonlib

--- a/openquake/commonlib/commands/__main__.py
+++ b/openquake/commonlib/commands/__main__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #  -*- coding: utf-8 -*-
 #  vim: tabstop=4 shiftwidth=4 softtabstop=4
 
@@ -20,11 +21,12 @@ import os
 import importlib
 
 from openquake.commonlib import sap, __version__
+from openquake.commonlib import commands
 
 
 def oq_lite():
     modnames = ['openquake.commonlib.commands.%s' % mod[:-3]
-                for mod in os.listdir(os.path.dirname(__file__))
+                for mod in os.listdir(commands.__path__[0])
                 if mod.endswith('.py') and not mod.startswith('_')]
     parsers = [importlib.import_module(modname).parser for modname in modnames]
     parser = sap.compose(parsers, version=__version__)

--- a/openquake/commonlib/commands/__main__.py
+++ b/openquake/commonlib/commands/__main__.py
@@ -20,8 +20,7 @@
 import os
 import importlib
 
-from openquake.commonlib import sap, __version__
-from openquake.commonlib import commands
+from openquake.commonlib import commands, sap, __version__
 
 
 def oq_lite():


### PR DESCRIPTION
This fixes the error in https://ci.openquake.org/job/master_oq-risklib/1391/
The reason is that oq-lite is now an entry point.
The demos are running now: https://ci.openquake.org/job/zdevel_oq-risklib/792

NB: on mac/linux it is convenient to define oq-lite as a symlink to `oq-risklib/openquake/commonlib/commands/__main__.py`