### PR TITLE
Added tests for the `show` command and the `export` command

### DIFF
--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -73,6 +73,7 @@ def run(job_ini, concurrent_tasks=None,
     logging.info('Total time spent: %s s', monitor.duration)
     logging.info('Memory allocated: %s', general.humansize(monitor.mem))
     monitor.flush()
+    return calc
 
 parser = sap.Parser(run)
 parser.arg('job_ini', 'calculation configuration file '

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -15,7 +15,7 @@
 
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
-
+from __future__ import print_function
 import logging
 
 from openquake.baselib import performance, general
@@ -68,11 +68,11 @@ def run(job_ini, concurrent_tasks=None,
         calc = run2(
             job_inis[0], job_inis[1], concurrent_tasks, exports, monitor)
 
-    logging.info('See the output with hdfview %s/output.hdf5',
-                 calc.datastore.calc_dir)
     logging.info('Total time spent: %s s', monitor.duration)
     logging.info('Memory allocated: %s', general.humansize(monitor.mem))
     monitor.flush()
+    print('See the output with hdfview %s/output.hdf5',
+          calc.datastore.calc_dir)
     return calc
 
 parser = sap.Parser(run)

--- a/openquake/commonlib/commands/show.py
+++ b/openquake/commonlib/commands/show.py
@@ -65,6 +65,8 @@ def show(calc_id, key=None, rlzs=None):
           (oq.description, ds.calc_dir))
     for key in ds:
         print(key, humansize(ds.getsize(key)))
+
+    # this part is experimental and not tested on purpose
     if rlzs and 'curves_by_trt_gsim' in ds:
         min_value = 0.01  # used in rmsep
         curves_by_rlz, mean_curves = combined_curves(ds)

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -85,15 +85,18 @@ output_weight 29.0'''
         self.assertIn('Number of tasks to be generated: 14', got)
 
 
-# also tests the `run` command
-class ShowExportTestCase(unittest.TestCase):
+class RunShowExportTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
         Build a datastore instance to show what it is inside
         """
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
-        cls.datastore = run(job_ini).datastore
+        with Print.patch() as cls.p:
+            cls.datastore = run(job_ini).datastore
+
+    def test_run_calc(self):
+        self.assertIn('See the output with hdfview', str(self.p))
 
     def test_show_calc(self):
         with Print.patch() as p:

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -3,8 +3,13 @@ import mock
 import shutil
 import tempfile
 import unittest
+
+from openquake.commonlib.datastore import DataStore
 from openquake.commonlib.commands.info import info
+from openquake.commonlib.commands.show import show
 from openquake.commonlib.commands.reduce import reduce
+from openquake.commonlib.commands.run import run
+from openquake.qa_tests_data.classical import case_1
 from openquake.qa_tests_data.classical_risk import case_3
 from openquake.qa_tests_data.scenario import case_4
 from openquake.qa_tests_data.event_based import case_5
@@ -77,6 +82,22 @@ output_weight 29.0'''
         got = str(p)
         self.assertIn('RlzsAssoc', got)
         self.assertIn('Number of tasks to be generated: 14', got)
+
+
+# also tests run
+class ShowTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Build a datastore instance to show what it is inside
+        """
+        job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
+        cls.datastore = run(job_ini).datastore
+
+    def test_1(self):
+        with Print.patch() as p:
+            show(self.datastore.calc_id, 'sitemesh')
+        self.assertEqual(str(p), '[(0.0, 0.0)]')
 
 
 class ReduceTestCase(unittest.TestCase):

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -7,6 +7,7 @@ import unittest
 from openquake.commonlib.datastore import DataStore
 from openquake.commonlib.commands.info import info
 from openquake.commonlib.commands.show import show
+from openquake.commonlib.commands.export import export
 from openquake.commonlib.commands.reduce import reduce
 from openquake.commonlib.commands.run import run
 from openquake.qa_tests_data.classical import case_1
@@ -84,8 +85,8 @@ output_weight 29.0'''
         self.assertIn('Number of tasks to be generated: 14', got)
 
 
-# also tests run
-class ShowTestCase(unittest.TestCase):
+# also tests the `run` command
+class ShowExportTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
@@ -94,10 +95,19 @@ class ShowTestCase(unittest.TestCase):
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         cls.datastore = run(job_ini).datastore
 
-    def test_1(self):
+    def test_show_calc(self):
+        with Print.patch() as p:
+            show(self.datastore.calc_id)
+        self.assertIn('sitemesh', str(p))
+
         with Print.patch() as p:
             show(self.datastore.calc_id, 'sitemesh')
         self.assertEqual(str(p), '[(0.0, 0.0)]')
+
+    def test_export_calc(self):
+        with Print.patch() as p:
+            export(self.datastore.calc_id, 'sitemesh', export_dir='/tmp')
+        self.assertIn("['/tmp/sitemesh.csv']", str(p))
 
 
 class ReduceTestCase(unittest.TestCase):


### PR DESCRIPTION
This closes https://bugs.launchpad.net/oq-engine/+bug/1462262. Other tests may be added in the future. Some feature are left untested on purpose since they are experimental and subject to change.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/805