### PR TITLE
MANIFEST.in: missing data from qa_tests_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md LICENSE
 
 recursive-include openquake/*/tests *.xml *.csv *.ini *.txt README
+recursive-include openquake/qa_tests_data *.xml *.csv *.ini *.txt README
 recursive-include openquake/commonlib/nrml_examples/ *.xml *.csv *.geojson


### PR DESCRIPTION
Otherwise data needed to run the `qa_tests` is not included in package

Test: https://ci.openquake.org/job/zdevel_oq-risklib/831/