### PR TITLE
Better xml error message

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -137,7 +137,7 @@ def get_params(job_inis):
     if smlt:
         params['inputs']['source'] = [
             os.path.join(base_path, src_path)
-            for src_path in source._collect_source_model_paths(smlt)]
+            for src_path in source.collect_source_model_paths(smlt)]
 
     return params
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -671,11 +671,13 @@ class CompositeSourceModel(collections.Sequence):
         return len(self.source_models)
 
 
-def _collect_source_model_paths(smlt):
+def collect_source_model_paths(smlt):
     """
     Given a path to a source model logic tree or a file-like, collect all of
     the soft-linked path names to the source models it contains and return them
     as a uniquified list (no duplicates).
+
+    :param smlt: source model logic tree file
     """
     src_paths = []
     try:

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -682,16 +682,16 @@ def collect_source_model_paths(smlt):
     src_paths = []
     try:
         tree = etree.parse(smlt)
+        for branch_set in tree.xpath('//nrml:logicTreeBranchSet',
+                                     namespaces=PARSE_NS_MAP):
+
+            if branch_set.get('uncertaintyType') == 'sourceModel':
+                for branch in branch_set.xpath(
+                        './nrml:logicTreeBranch/nrml:uncertaintyModel',
+                        namespaces=PARSE_NS_MAP):
+                    src_paths.append(branch.text)
     except Exception as exc:
         raise Exception('%s: %s in %s' % (exc.__class__.__name__, exc, smlt))
-    for branch_set in tree.xpath('//nrml:logicTreeBranchSet',
-                                 namespaces=PARSE_NS_MAP):
-
-        if branch_set.get('uncertaintyType') == 'sourceModel':
-            for branch in branch_set.xpath(
-                    './nrml:logicTreeBranch/nrml:uncertaintyModel',
-                    namespaces=PARSE_NS_MAP):
-                src_paths.append(branch.text)
     return sorted(set(src_paths))
 
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -678,7 +678,10 @@ def _collect_source_model_paths(smlt):
     as a uniquified list (no duplicates).
     """
     src_paths = []
-    tree = etree.parse(smlt)
+    try:
+        tree = etree.parse(smlt)
+    except Exception as exc:
+        raise Exception('%s: %s in %s' % (exc.__class__.__name__, exc, smlt))
     for branch_set in tree.xpath('//nrml:logicTreeBranchSet',
                                  namespaces=PARSE_NS_MAP):
 

--- a/openquake/commonlib/tests/data/source_model_logic_tree.xml
+++ b/openquake/commonlib/tests/data/source_model_logic_tree.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"branchSetID="bs1">
+                <logicTreeBranch branchID="b11">
+                  <uncertaintyModel>
+                    taiwan_source_model-141027.xml
+                  </uncertaintyModel>
+                  <uncertaintyWeight>
+                    1.0
+                  </uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -33,7 +33,7 @@ from decimal import Decimal
 from mock import Mock
 
 import openquake.hazardlib
-from openquake.commonlib import logictree, readinput, tests
+from openquake.commonlib import logictree, readinput, tests, source
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
@@ -1816,3 +1816,12 @@ class LogicTreeProcessorParsePathTestCase(unittest.TestCase):
         self.assertEqual(self.uncertainties_applied,
                          [('maxMagGRRelative', 0.2),
                           ('bGRRelative', 0.1)])
+
+    def test_parse_invalid_smlt(self):
+        smlt = os.path.join(DATADIR, 'source_model_logic_tree.xml')
+        with self.assertRaises(Exception) as ctx:
+            source.collect_source_model_paths(smlt)
+        msg = str(ctx.exception)
+        self.assertIn('XMLSyntaxError:', msg)
+        # make sure the file name is in the error message
+        self.assertIn('tests/data/source_model_logic_tree.xml', msg)


### PR DESCRIPTION
In particular, the name of the invalid file must appear. See https://bugs.launchpad.net/oq-engine/+bug/1437188. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/877