### PR TITLE
Classical damage tests

### DIFF
--- a/openquake/qa_tests_data/classical_damage/case_4a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_4a/job_risk.ini
@@ -14,4 +14,4 @@ fragility_file = fragility_model.xml
 
 [calculation]
 # years
-investigation_time = 1
+risk_investigation_time = 1

--- a/openquake/qa_tests_data/classical_damage/case_4b/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_4b/job_risk.ini
@@ -14,4 +14,4 @@ fragility_file = fragility_model.xml
 
 [calculation]
 # years
-investigation_time = 75
+risk_investigation_time = 75

--- a/openquake/qa_tests_data/classical_damage/case_4c/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_4c/job_risk.ini
@@ -14,4 +14,4 @@ fragility_file = fragility_model.xml
 
 [calculation]
 # years
-investigation_time = 75
+risk_investigation_time = 75

--- a/openquake/qa_tests_data/classical_damage/case_5a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_5a/job_risk.ini
@@ -14,4 +14,4 @@ fragility_file = fragility_model.xml
 
 [calculation]
 # years
-investigation_time = 1
+risk_investigation_time = 1

--- a/openquake/qa_tests_data/classical_damage/case_6a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_6a/job_risk.ini
@@ -15,4 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 steps_per_interval = 4
 # years
-investigation_time = 100
+risk_investigation_time = 100

--- a/openquake/qa_tests_data/classical_damage/case_6b/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_6b/job_risk.ini
@@ -14,5 +14,5 @@ fragility_file = fragility_model.xml
 
 [calculation]
 # years
-investigation_time = 100
+risk_investigation_time = 100
 continuous_fragility_discretization = 28

--- a/openquake/qa_tests_data/classical_damage/case_7a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7a/job_risk.ini
@@ -15,4 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 steps_per_interval = 4
 # years
-investigation_time = 100
+risk_investigation_time = 100

--- a/openquake/qa_tests_data/classical_damage/case_7b/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7b/job_risk.ini
@@ -15,4 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 steps_per_interval = 4
 # years
-investigation_time = 100
+risk_investigation_time = 100

--- a/openquake/qa_tests_data/classical_damage/case_7c/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7c/job_risk.ini
@@ -15,4 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 steps_per_interval = 4
 # years
-investigation_time = 100
+risk_investigation_time = 100

--- a/openquake/qa_tests_data/classical_damage/case_8a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_8a/job_risk.ini
@@ -15,4 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 steps_per_interval = 4
 # years
-investigation_time = 1
+risk_investigation_time = 1


### PR DESCRIPTION
Fixes the broken tests discovered in https://bugs.launchpad.net/oq-engine/+bug/1473365.
See the run in the engine (the classical_damage tests do not run in oq-lite yet):
https://ci.openquake.org/job/zdevel_oq-engine/1353