### PR TITLE
Using 100 SES instead of 200 to save memory

### DIFF
--- a/demos/ProbabilisticEventBased/job_hazard.ini
+++ b/demos/ProbabilisticEventBased/job_hazard.ini
@@ -39,8 +39,8 @@ investigation_time = 50.0
 truncation_level = 3
 # km
 maximum_distance = 200.0
-# using 100 SES instead of 200 to save memory
-ses_per_logic_tree_path = 100
+# using 2 SES instead of 200 to save memory
+ses_per_logic_tree_path = 2
 
 [output]
 

--- a/demos/ProbabilisticEventBased/job_hazard.ini
+++ b/demos/ProbabilisticEventBased/job_hazard.ini
@@ -39,8 +39,8 @@ investigation_time = 50.0
 truncation_level = 3
 # km
 maximum_distance = 200.0
-# using 2 SES instead of 200 to save memory
-ses_per_logic_tree_path = 2
+# using 100 SES instead of 200 to save memory
+ses_per_logic_tree_path = 100
 
 [output]
 

--- a/demos/ProbabilisticEventBased/job_hazard.ini
+++ b/demos/ProbabilisticEventBased/job_hazard.ini
@@ -39,7 +39,8 @@ investigation_time = 50.0
 truncation_level = 3
 # km
 maximum_distance = 200.0
-ses_per_logic_tree_path = 200
+# using 100 SES instead of 200 to save memory
+ses_per_logic_tree_path = 100
 
 [output]
 


### PR DESCRIPTION
Master is currently broken because of an OutOfMemory error in the ProbabilisticEventBasedDemo:
https://ci.openquake.org/job/master_oq-engine/1879/console

I am reducing the memory consumption so that the demo run again (see
https://ci.openquake.org/job/zdevel_oq-engine/1355/).  Further investigation will be needed when I will come back from my vacation. This is not a big issue since all tests are green.
