### PR TITLE
Added an header to the exported event loss table

### DIFF
--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -207,11 +207,13 @@ def export_event_loss(ekey, dstore):
     """
     name, fmt = ekey
     fnames = []
+    header = ['rupture_tag', 'aggregate_loss', 'insured_loss']
     for i, data in enumerate(dstore[ekey[0]]):
         for loss_type in data:
             dest = os.path.join(
                 dstore.export_dir, 'rlz-%03d-%s-%s.csv' % (i, loss_type, name))
-            writers.write_csv(dest, sorted(data[loss_type]), fmt='%10.6E')
+            writers.write_csv(
+                dest, [header] + sorted(data[loss_type]), fmt='%10.6E')
             fnames.append(dest)
     return fnames
 

--- a/openquake/qa_tests_data/event_based_risk/case_2/expected/rlz-000-structural-event_loss.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_2/expected/rlz-000-structural-event_loss.csv
@@ -1,3 +1,4 @@
+rupture_tag,aggregate_loss,insured_loss
 col=00|ses=0003|src=1|rup=001-01,3.461644E+02,0.000000E+00
 col=00|ses=0003|src=1|rup=001-02,1.018580E+03,0.000000E+00
 col=00|ses=0003|src=2|rup=001-01,9.634527E+01,0.000000E+00

--- a/openquake/qa_tests_data/event_based_risk/case_2/expected/rlz-000-structural-event_loss_asset.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_2/expected/rlz-000-structural-event_loss_asset.csv
@@ -1,3 +1,4 @@
+rupture_tag,aggregate_loss,insured_loss
 col=00|ses=0003|src=1|rup=001-01,a0,3.461644E+02,0.000000E+00
 col=00|ses=0003|src=1|rup=001-02,a0,1.018580E+03,0.000000E+00
 col=00|ses=0003|src=2|rup=001-01,a1,9.634527E+01,0.000000E+00


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1486421. The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/933/