### PR TITLE
Log a warning for far away site parameters

### DIFF
--- a/openquake/commonlib/calculators/base.py
+++ b/openquake/commonlib/calculators/base.py
@@ -211,7 +211,7 @@ class HazardCalculator(BaseCalculator):
         for assets in self.assets_by_site:
             if len(assets):
                 lon, lat = assets[0].location
-                site = siteobjects.get_closest(lon, lat, maximum_distance)
+                site, _ = siteobjects.get_closest(lon, lat, maximum_distance)
                 if site:
                     assets_by_sid += {site.id: list(assets)}
         if not assets_by_sid:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1,7 +1,7 @@
 #  -*- coding: utf-8 -*-
 #  vim: tabstop=4 shiftwidth=4 softtabstop=4
 
-#  Copyright (c) 2014, GEM Foundation
+#  Copyright (c) 2014-2015, GEM Foundation
 
 #  OpenQuake is free software: you can redistribute it and/or modify it
 #  under the terms of the GNU Affero General Public License as published
@@ -45,6 +45,7 @@ from openquake.commonlib import source, sourceconverter
 
 # the following is quite arbitrary, it gives output weights that I like (MS)
 NORMALIZATION_FACTOR = 1E-2
+MAX_PARAM_DISTANCE = 5  # km, given by Graeme Weatherill
 
 info_dt = numpy.dtype([('input_weight', float),
                        ('output_weight', float),
@@ -254,8 +255,11 @@ def get_site_collection(oqparam, mesh=None, site_ids=None,
                 get_site_model(oqparam))
         sitecol = []
         for i, pt in zip(site_ids, mesh):
-            param = site_model_params.\
+            param, dist = site_model_params.\
                 get_closest(pt.longitude, pt.latitude)
+            if dist >= MAX_PARAM_DISTANCE:
+                logging.warn('The site parameter associated to %s came from a '
+                             'distance of %d km!' % (pt, dist))
             sitecol.append(
                 site.Site(pt, param.vs30, param.measured,
                           param.z1pt0, param.z2pt5, param.backarc, i))

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -45,7 +45,7 @@ from openquake.commonlib import source, sourceconverter
 
 # the following is quite arbitrary, it gives output weights that I like (MS)
 NORMALIZATION_FACTOR = 1E-2
-MAX_PARAM_DISTANCE = 5  # km, given by Graeme Weatherill
+MAX_SITE_MODEL_DISTANCE = 5  # km, given by Graeme Weatherill
 
 info_dt = numpy.dtype([('input_weight', float),
                        ('output_weight', float),
@@ -257,7 +257,7 @@ def get_site_collection(oqparam, mesh=None, site_ids=None,
         for i, pt in zip(site_ids, mesh):
             param, dist = site_model_params.\
                 get_closest(pt.longitude, pt.latitude)
-            if dist >= MAX_PARAM_DISTANCE:
+            if dist >= MAX_SITE_MODEL_DISTANCE:
                 logging.warn('The site parameter associated to %s came from a '
                              'distance of %d km!' % (pt, dist))
             sitecol.append(


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1472252. The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/958. This PR requires the companion https://github.com/gem/oq-hazardlib/pull/371