### PR TITLE
Increased the export precision

### DIFF
--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -356,8 +356,8 @@ class EventBasedGMFXMLWriter(object):
         self.sm_lt_path = sm_lt_path
         self.gsim_lt_path = gsim_lt_path
 
-    # we want at least 1+6 digits of precision
-    def serialize(self, data, fmt='%8.6E'):
+    # we want at least 1+7 digits of precision
+    def serialize(self, data, fmt='%10.7E'):
         """
         Serialize a collection of ground motion fields to XML.
 

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -356,8 +356,8 @@ class EventBasedGMFXMLWriter(object):
         self.sm_lt_path = sm_lt_path
         self.gsim_lt_path = gsim_lt_path
 
-    # 5 digits after the decimal point is the precision of lon/lat
-    def serialize(self, data, fmt='%9.5E'):
+    # we want at least 1+6 digits of precision
+    def serialize(self, data, fmt='%8.6E'):
         """
         Serialize a collection of ground motion fields to XML.
 

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -356,7 +356,8 @@ class EventBasedGMFXMLWriter(object):
         self.sm_lt_path = sm_lt_path
         self.gsim_lt_path = gsim_lt_path
 
-    def serialize(self, data):
+    # 5 digits after the decimal point is the precision of lon/lat
+    def serialize(self, data, fmt='%9.5E'):
         """
         Serialize a collection of ground motion fields to XML.
 
@@ -400,7 +401,7 @@ class EventBasedGMFXMLWriter(object):
         gmf_container.nodes = gmf_set_nodes
 
         with open(self.dest, 'w') as dest:
-            nrml.write([gmf_container], dest)
+            nrml.write([gmf_container], dest, fmt)
 
 
 def rupture_to_element(rupture, parent=None):

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -363,7 +363,7 @@ def read_lazy(source, lazytags):
     return nodes
 
 
-def write(nodes, output=sys.stdout, fmt='%8.6E'):
+def write(nodes, output=sys.stdout, fmt='%10.7E'):
     """
     Convert nodes into a NRML file. output must be a file
     object open in write mode. If you want to perform a

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -363,7 +363,7 @@ def read_lazy(source, lazytags):
     return nodes
 
 
-def write(nodes, output=sys.stdout, fmt='%8.4E'):
+def write(nodes, output=sys.stdout, fmt='%9.5E'):
     """
     Convert nodes into a NRML file. output must be a file
     object open in write mode. If you want to perform a

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -363,7 +363,7 @@ def read_lazy(source, lazytags):
     return nodes
 
 
-def write(nodes, output=sys.stdout, fmt='%9.5E'):
+def write(nodes, output=sys.stdout, fmt='%8.6E'):
     """
     Convert nodes into a NRML file. output must be a file
     object open in write mode. If you want to perform a

--- a/openquake/commonlib/tests/expected_gmf.xml
+++ b/openquake/commonlib/tests/expected_gmf.xml
@@ -17,8 +17,8 @@ xmlns:gml="http://www.opengis.net/gml"
             saDamping="5.0"
             saPeriod="0.1"
             >
-                <node gmv="0.0000E+00" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0000E-01" lat="1.0000E-01" lon="1.0000E-01"/>
+                <node gmv="0.0000000E+00" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0000000E-01" lat="1.0000000E-01" lon="1.0000000E-01"/>
             </gmf>
             <gmf
             IMT="SA"
@@ -26,8 +26,8 @@ xmlns:gml="http://www.opengis.net/gml"
             saDamping="5.0"
             saPeriod="0.2"
             >
-                <node gmv="4.0000E-01" lat="2.0000E-01" lon="2.0000E-01"/>
-                <node gmv="6.0000E-01" lat="3.0000E-01" lon="3.0000E-01"/>
+                <node gmv="4.0000000E-01" lat="2.0000000E-01" lon="2.0000000E-01"/>
+                <node gmv="6.0000000E-01" lat="3.0000000E-01" lon="3.0000000E-01"/>
             </gmf>
         </gmfSet>
         <gmfSet
@@ -40,15 +40,15 @@ xmlns:gml="http://www.opengis.net/gml"
             saDamping="5.0"
             saPeriod="0.3"
             >
-                <node gmv="8.0000E-01" lat="4.0000E-01" lon="4.0000E-01"/>
-                <node gmv="1.0000E+00" lat="5.0000E-01" lon="5.0000E-01"/>
+                <node gmv="8.0000000E-01" lat="4.0000000E-01" lon="4.0000000E-01"/>
+                <node gmv="1.0000000E+00" lat="5.0000000E-01" lon="5.0000000E-01"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="i=4"
             >
-                <node gmv="1.2000E+00" lat="6.0000E-01" lon="6.0000E-01"/>
-                <node gmv="1.4000E+00" lat="7.0000E-01" lon="7.0000E-01"/>
+                <node gmv="1.2000000E+00" lat="6.0000000E-01" lon="6.0000000E-01"/>
+                <node gmv="1.4000000E+00" lat="7.0000000E-01" lon="7.0000000E-01"/>
             </gmf>
         </gmfSet>
         <gmfSet
@@ -59,15 +59,15 @@ xmlns:gml="http://www.opengis.net/gml"
             IMT="PGA"
             ruptureId="i=5"
             >
-                <node gmv="1.6000E+00" lat="8.0000E-01" lon="8.0000E-01"/>
-                <node gmv="1.8000E+00" lat="9.0000E-01" lon="9.0000E-01"/>
+                <node gmv="1.6000000E+00" lat="8.0000000E-01" lon="8.0000000E-01"/>
+                <node gmv="1.8000000E+00" lat="9.0000000E-01" lon="9.0000000E-01"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="i=6"
             >
-                <node gmv="2.0000E+00" lat="1.0000E+00" lon="1.0000E+00"/>
-                <node gmv="2.2000E+00" lat="1.1000E+00" lon="1.1000E+00"/>
+                <node gmv="2.0000000E+00" lat="1.0000000E+00" lon="1.0000000E+00"/>
+                <node gmv="2.2000000E+00" lat="1.1000000E+00" lon="1.1000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>

--- a/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
+++ b/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
@@ -15,25 +15,25 @@ xmlns:gml="http://www.opengis.net/gml"
             IMT="PGA"
             ruptureId="col=00|ses=0058|src=1|rup=1671-01"
             >
-                <node gmv="5.2034E-01" lat="0.0000E+00" lon="0.0000E+00"/>
+                <node gmv="5.2034182E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="col=00|ses=0122|src=1|rup=085-01"
             >
-                <node gmv="2.4500E-01" lat="0.0000E+00" lon="0.0000E+00"/>
+                <node gmv="2.4500016E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="col=00|ses=0250|src=1|rup=910-01"
             >
-                <node gmv="3.6253E-01" lat="0.0000E+00" lon="0.0000E+00"/>
+                <node gmv="3.6253172E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="col=00|ses=0262|src=1|rup=176-01"
             >
-                <node gmv="2.5582E-01" lat="0.0000E+00" lon="0.0000E+00"/>
+                <node gmv="2.5582224E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>

--- a/openquake/qa_tests_data/scenario/case_9/LinLee2008SSlab_gmf.xml
+++ b/openquake/qa_tests_data/scenario/case_9/LinLee2008SSlab_gmf.xml
@@ -14,81 +14,81 @@ xmlns:gml="http://www.opengis.net/gml"
             IMT="PGA"
             ruptureId="scenario-0000000000"
             >
-                <node gmv="4.4478E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.3267E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6804E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4478257E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3267247E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6803673E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000001"
             >
-                <node gmv="2.6791E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.2100E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3208E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.6791192E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.2100350E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3208074E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000002"
             >
-                <node gmv="4.5665E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7939E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8925E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.5664554E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.7939416E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.8924990E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000003"
             >
-                <node gmv="1.8239E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.2454E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6608E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="1.8239195E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2453905E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6607578E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000004"
             >
-                <node gmv="4.3230E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6538E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3359E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.3229934E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.6538004E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3359390E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000005"
             >
-                <node gmv="3.7556E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.8431E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5791E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.7556200E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8431098E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5791387E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000006"
             >
-                <node gmv="1.9166E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.8688E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.1226E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="1.9166424E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.8687805E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1225689E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000007"
             >
-                <node gmv="2.6450E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6272E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4343E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.6449887E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6272444E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4343031E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000008"
             >
-                <node gmv="2.4173E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6299E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1626E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.4173466E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6299429E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.1625759E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000009"
             >
-                <node gmv="3.6499E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.8457E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2435E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.6499113E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.8456849E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.2435391E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>

--- a/openquake/qa_tests_data/scenario/case_9/YoungsEtAl1997SSlab_gmf.xml
+++ b/openquake/qa_tests_data/scenario/case_9/YoungsEtAl1997SSlab_gmf.xml
@@ -14,81 +14,81 @@ xmlns:gml="http://www.opengis.net/gml"
             IMT="PGA"
             ruptureId="scenario-0000000000"
             >
-                <node gmv="8.0228E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6427E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="3.3600E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="8.0228379E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6426871E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="3.3599555E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000001"
             >
-                <node gmv="3.7153E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="6.2847E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.3310E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.7153429E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="6.2847313E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.3309942E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000002"
             >
-                <node gmv="8.3500E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5974E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="4.0248E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="8.3500268E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5973684E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="4.0247709E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000003"
             >
-                <node gmv="2.0721E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.6524E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="3.3006E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.0721106E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.6523501E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="3.3005915E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000004"
             >
-                <node gmv="7.6834E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="4.7075E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.3717E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.6833968E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="4.7074650E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.3716684E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000005"
             >
-                <node gmv="6.2053E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7062E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="3.0574E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.2052913E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7062402E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="3.0574237E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000006"
             >
-                <node gmv="2.2342E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="5.2986E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="4.7908E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.2341725E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="5.2985863E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="4.7907914E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000007"
             >
-                <node gmv="3.6437E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.2398E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.6419E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.6437033E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2398160E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.6418576E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000008"
             >
-                <node gmv="3.1783E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.2455E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9204E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.1782536E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2454591E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9203615E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
             ruptureId="scenario-0000000009"
             >
-                <node gmv="5.9420E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="5.2339E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.1271E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.9419981E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="5.2339422E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1270813E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>


### PR DESCRIPTION
Internally lons and lats have 8 digits of precision, i.e. we can distinguish 179.00000 and 179.00001 (3 digits before the decimal point + 5 digits after. This level of precision should be kept when exporting.
See https://bugs.launchpad.net/oq-engine/+bug/1488418 and the tests https://ci.openquake.org/job/zdevel_oq-risklib/972/