### PR TITLE
Imported with_slots from baselib

### DIFF
--- a/openquake/commonlib/node.py
+++ b/openquake/commonlib/node.py
@@ -147,6 +147,7 @@ import pprint as pp
 import io
 from contextlib import contextmanager
 from openquake.baselib.python3compat import raise_, exec_
+from openquake.baselib.slots import with_slots
 from openquake.commonlib.writers import StreamingXMLWriter
 
 try:
@@ -171,52 +172,6 @@ except ImportError:
     def iterparse(source, events=('end',), remove_comments=True, **kw):
         """Thin wrapper around ElementTree.iterparse"""
         return ElementTree.iterparse(source, events, **kw)
-
-
-## this is duplicated from hazardlib to avoid a dependency
-def with_slots(cls):
-    """
-    Decorator for a class with __slots__. It automatically defines
-    the methods __eq__, __ne__, assert_equal, __getstate__ and __setstate__
-    """
-    def _compare(self, other):
-        for slot in self.__class__.__slots__:
-            source = getattr(self, slot)
-            target = getattr(other, slot)
-            yield slot, source, target, source == target
-
-    def __eq__(self, other):
-        """True if self and other have the same slots"""
-        return all(eq for slot, source, target, eq in _compare(self, other))
-
-    def __ne__(self, other):
-        """True if self and other have different slots"""
-        return not self.__eq__(other)
-
-    def assert_equal(self, other):
-        """Check if self and other have the same slots"""
-        for slot, source, target, eq in _compare(self, other):
-            if not eq:
-                raise AssertionError('slot %s: %s is different from %s' %
-                                     (slot, source, target))
-
-    def __getstate__(self):
-        """Return a dictionary with the slots"""
-        return dict((slot, getattr(self, slot))
-                    for slot in self.__class__.__slots__)
-
-    def __setstate__(self, state):
-        """Set the slots"""
-        for slot in self.__class__.__slots__:
-            setattr(self, slot, state[slot])
-
-    cls.__slots__  # raise an AttributeError for missing slots
-    cls.__eq__ = __eq__
-    cls.__ne__ = __ne__
-    cls.assert_equal = assert_equal
-    cls.__getstate__ = __getstate__
-    cls.__setstate__ = __setstate__
-    return cls
 
 
 ######################## utilities for the Node class #########################

--- a/openquake/commonlib/tests/__init__.py
+++ b/openquake/commonlib/tests/__init__.py
@@ -49,3 +49,4 @@ def check_equal(filepath, expected, actual_path):
 
 def test_independent():
     assert_independent('openquake.commonlib.parallel', 'openquake.hazardlib')
+    assert_independent('openquake.commonlib.node', 'openquake.hazardlib')


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1489278. This the companion of 
https://github.com/gem/oq-hazardlib/pull/372. The tests are green: 
https://ci.openquake.org/job/zdevel_oq-risklib/979/