### PR TITLE
Restricted the valid source IDs

### DIFF
--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -153,7 +153,7 @@ class ValidNode(LiteralNode):
         weight=valid.probability,
         alongStrike=valid.probability,
         downDip=valid.probability,
-        id=valid.source_id,
+        id=valid.simple_id,
         )
 
 

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -153,6 +153,7 @@ class ValidNode(LiteralNode):
         weight=valid.probability,
         alongStrike=valid.probability,
         downDip=valid.probability,
+        id=valid.source_id,
         )
 
 

--- a/openquake/commonlib/tests/valid_test.py
+++ b/openquake/commonlib/tests/valid_test.py
@@ -10,6 +10,12 @@ class ValidationTestCase(unittest.TestCase):
     def test_simple_id(self):
         self.assertEqual(valid.simple_id('0'), '0')
         self.assertEqual(valid.simple_id('1-0'), '1-0')
+        self.assertEqual(valid.simple_id('a_x'), 'a_x')
+        with self.assertRaises(ValueError) as ctx:
+            valid.simple_id('a x')
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid ID 'a x': the only accepted chars are a-zA-Z0-9_-")
         with self.assertRaises(ValueError):
             valid.simple_id('0|1')
         with self.assertRaises(ValueError):

--- a/openquake/commonlib/tests/valid_test.py
+++ b/openquake/commonlib/tests/valid_test.py
@@ -7,15 +7,17 @@ from openquake.commonlib import valid
 class ValidationTestCase(unittest.TestCase):
     # more is done in the doctests inside commonlib.valid
 
-    def test_source_id(self):
-        self.assertEqual(valid.source_id('0'), '0')
-        self.assertEqual(valid.source_id('1-0'), '1-0')
+    def test_simple_id(self):
+        self.assertEqual(valid.simple_id('0'), '0')
+        self.assertEqual(valid.simple_id('1-0'), '1-0')
         with self.assertRaises(ValueError):
-            valid.source_id('0|1')
+            valid.simple_id('0|1')
         with self.assertRaises(ValueError):
-            valid.source_id('à')
+            valid.simple_id('à')
         with self.assertRaises(ValueError):
-            valid.source_id('\t')
+            valid.simple_id('\t')
+        with self.assertRaises(ValueError):
+            valid.simple_id('a' * 101)
 
     def test_name(self):
         self.assertEqual(valid.name('x'), 'x')

--- a/openquake/commonlib/tests/valid_test.py
+++ b/openquake/commonlib/tests/valid_test.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import unittest
 from openquake.hazardlib import imt
 from openquake.commonlib import valid
@@ -5,6 +6,16 @@ from openquake.commonlib import valid
 
 class ValidationTestCase(unittest.TestCase):
     # more is done in the doctests inside commonlib.valid
+
+    def test_source_id(self):
+        self.assertEqual(valid.source_id('0'), '0')
+        self.assertEqual(valid.source_id('1-0'), '1-0')
+        with self.assertRaises(ValueError):
+            valid.source_id('0|1')
+        with self.assertRaises(ValueError):
+            valid.source_id('à')
+        with self.assertRaises(ValueError):
+            valid.source_id('\t')
 
     def test_name(self):
         self.assertEqual(valid.name('x'), 'x')

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -160,6 +160,16 @@ name = Regex(r'^[a-zA-Z_]\w*$')
 name_with_dashes = Regex(r'^[a-zA-Z_][\w\-]*$')
 
 
+def source_id(value):
+    """
+    Check the source id; the only accepted chars are a-zA-Z0-9_-
+    """
+    if re.match(r'^[\w_\-]+$', value):
+        return value
+    raise ValueError(
+        'The source id %r contains invalid characters' % value)
+
+
 class FloatRange(object):
     def __init__(self, minrange, maxrange):
         self.minrange = minrange

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -172,7 +172,7 @@ def simple_id(value):
     if re.match(r'^[\w_\-]+$', value):
         return value
     raise ValueError(
-        'The ID %r contains invalid characters' % value)
+        'Invalid ID %r: the only accepted chars are a-zA-Z0-9_-' % value)
 
 
 class FloatRange(object):

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -159,15 +159,20 @@ name = Regex(r'^[a-zA-Z_]\w*$')
 
 name_with_dashes = Regex(r'^[a-zA-Z_][\w\-]*$')
 
+MAX_ID_LENGTH = 100
 
-def source_id(value):
+
+def simple_id(value):
     """
     Check the source id; the only accepted chars are a-zA-Z0-9_-
     """
+    if len(value) > MAX_ID_LENGTH:
+        raise ValueError('The ID %r is longer than %d character' %
+                         (value, MAX_ID_LENGTH))
     if re.match(r'^[\w_\-]+$', value):
         return value
     raise ValueError(
-        'The source id %r contains invalid characters' % value)
+        'The ID %r contains invalid characters' % value)
 
 
 class FloatRange(object):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1490490. The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/986