### PR TITLE
Optimization on the average losses computation

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -285,13 +285,11 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                     saved[self.outs[o]] += losses.nbytes
                 elif o == AVGLOSS:  # average losses
                     lt = self.riskmodel.loss_types[l]
-                    [avgloss_by_aid] = data
-                    try:
-                        pairs = [avgloss_by_aid[i] * asset[lt]
-                                 for i, asset in enumerate(self.assetcol)]
-                    except:
-                        import pdb; pdb.set_trace()
-                    avglosses = numpy.array(pairs, numpy.float32)
+                    [avgloss] = data
+                    avglosses = numpy.array(
+                        [avgloss[i] * asset[lt]
+                         for i, asset in enumerate(self.assetcol)],
+                        numpy.float32)
                     self.datasets[o, l, r].dset[:] = avglosses
                     saved[self.outs[o]] += avglosses.nbytes
                 elif cb.user_provided:  # risk curves

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -19,6 +19,7 @@
 import os
 import re
 import shutil
+import logging
 from openquake.baselib.python3compat import pickle
 import collections
 
@@ -254,9 +255,11 @@ class DataStore(collections.MutableMapping):
         if hasattr(os, 'symlink'):  # Unix, Max
             link_name = os.path.join(
                 self.datadir, name.strip('/').replace('/', '-')) + '.hdf5'
-            if os.path.exists(link_name):
-                os.remove(link_name)
-            os.symlink(self.hdf5path, link_name)
+            try:
+                os.symlink(self.hdf5path, link_name)
+            except OSError as err:
+                # this is not an issue
+                logging.info('Could not create symlink %s: %s', link_name, err)
 
     def clear(self):
         """Remove the datastore from the file system"""


### PR DESCRIPTION
By replacing dictionaries with arrays we can improve a lot the aggregation time on the controller node.
Fixes #378; the tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/1043/

PS: I am also trapping the case in which a symlink to the datastore cannot be made. This is not a problem since the symlinks are not used by the engine in any way, they are just an undocumented convenience for Anirudh.