### PR TITLE
Removed support for the old event based calculators

### DIFF
--- a/demos/ProbabilisticEventBased/job_risk.ini
+++ b/demos/ProbabilisticEventBased/job_risk.ini
@@ -1,7 +1,7 @@
 [general]
 
 description = Probabilistic Event-Based Hazard Demo
-calculation_mode = ebr
+calculation_mode = event_based_risk
 random_seed = 1024
 
 [risk]

--- a/doc/openquake.calculators.rst
+++ b/doc/openquake.calculators.rst
@@ -25,10 +25,10 @@ calculators Package
     :undoc-members:
     :show-inheritance:
 
-:mod:`ebr` Module
+:mod:`event_based_risk` Module
 ------------------
 
-.. automodule:: openquake.calculators.ebr
+.. automodule:: openquake.calculators.event_based_risk
     :members:
     :undoc-members:
     :show-inheritance:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -218,6 +218,8 @@ def get_geom(surface, is_from_fault_source, is_multi_surface):
     return lons, lats, depths
 
 
+# this is very ugly for compatibility with the Django API in the engine
+# TODO: simplify this, now that the old calculators have been removed
 class SESRupture(object):
     def __init__(self, rupture, indices, seed, tag, col_id):
         self.rupture = rupture
@@ -477,6 +479,7 @@ def make_gmfs(ses_ruptures, sitecol, imts, gsims,
         with gmf_mon:
             for sr in sesruptures:
                 gmf = computer.compute([sr.seed])[0]
+                # TODO: change idx to rup_idx, also in hazardlib
                 gmf['idx'] = sr.ordinal
                 gmfs.append(gmf)
     ctx_mon.flush()

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -145,7 +145,7 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
     return result
 
 
-@base.calculators.add('event_based_risk', 'ebr')
+@base.calculators.add('event_based_risk')
 class EventBasedRiskCalculator(base.RiskCalculator):
     """
     Event based PSHA calculator generating the event loss table and

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -38,7 +38,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
     def test_case_3(self):
         self.assert_stats_ok(case_3)
 
-    @attr('qa', 'risk', 'ebr')
+    @attr('qa', 'risk', 'event_based_risk')
     def test_case_2bis(self):
         # test for a single realization
         out = self.run_calc(case_2.__file__, 'job_loss.ini', exports='csv',
@@ -56,7 +56,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         [fname] = out['hcurves', 'csv']
         self.assertEqualFiles('expected/hazard_curve-mean.csv', fname)
 
-    @attr('qa', 'risk', 'ebr')
+    @attr('qa', 'risk', 'event_based_risk')
     def test_case_4(self):
         # Turkey with SHARE logic tree
         out = self.run_calc(case_4.__file__, 'job_h.ini,job_r.ini',

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -34,8 +34,7 @@ HAZARD_CALCULATORS = [
 
 RISK_CALCULATORS = [
     'classical_risk', 'event_based_risk', 'scenario_risk',
-    'classical_bcr', 'event_based_bcr', 'scenario_damage',
-    'classical_damage', 'ebr']
+    'classical_bcr', 'scenario_damage', 'classical_damage']
 
 CALCULATORS = HAZARD_CALCULATORS + RISK_CALCULATORS
 

--- a/openquake/commonlib/reportwriter.py
+++ b/openquake/commonlib/reportwriter.py
@@ -77,7 +77,7 @@ def build_report(job_ini, output_dir=None):
     if 'num_ruptures' in ds:
         rw.add('rupture_collections')
         rw.add('col_rlz_assocs')
-    if oq.calculation_mode in ('classical', 'event_based', 'ebr'):
+    if oq.calculation_mode in ('classical', 'event_based', 'event_based_risk'):
         rw.add('data_transfer')
     rw.save(report)
     return report

--- a/openquake/commonlib/writers.py
+++ b/openquake/commonlib/writers.py
@@ -261,6 +261,7 @@ def write_csv(dest, data, sep=',', fmt='%12.8E', header=None):
        optional list with the names of the columns to display
     """
     if not hasattr(dest, 'getvalue'):
+        # not a StringIO, assume dest is a filename
         dest = open(dest, 'w')
     if len(data) == 0:
         logging.warn('Not generating %s, it would be empty', dest)

--- a/openquake/commonlib/writers.py
+++ b/openquake/commonlib/writers.py
@@ -253,13 +253,15 @@ def extract_from(data, fields):
 
 def write_csv(dest, data, sep=',', fmt='%12.8E', header=None):
     """
-    :param dest: destination filename
+    :param dest: destination filename or io.StringIO instance
     :param data: array to save
     :param sep: separator to use (default comma)
     :param fmt: formatting string (default '%12.8E')
     :param header:
        optional list with the names of the columns to display
     """
+    if not hasattr(dest, 'getvalue'):
+        dest = open(dest, 'w')
     if len(data) == 0:
         logging.warn('Not generating %s, it would be empty', dest)
         return dest
@@ -271,25 +273,29 @@ def write_csv(dest, data, sep=',', fmt='%12.8E', header=None):
         autoheader = []
     else:
         autoheader = build_header(data.dtype)
-    with open(dest, 'w') as f:
-        someheader = header or autoheader
-        if someheader:
-            f.write(sep.join(someheader) + '\n')
 
-        if autoheader:
-            all_fields = [col.split(':', 1)[0].split('-')
-                          for col in autoheader]
-            for record in data:
-                row = []
-                for fields in all_fields:
-                    row.append(extract_from(record, fields))
-                f.write(sep.join(scientificformat(col, fmt)
-                                 for col in row) + '\n')
-        else:
-            for row in data:
-                f.write(sep.join(scientificformat(col, fmt)
-                                 for col in row) + '\n')
-    return dest
+    someheader = header or autoheader
+    if someheader:
+        dest.write(sep.join(someheader) + u'\n')
+
+    if autoheader:
+        all_fields = [col.split(':', 1)[0].split('-')
+                      for col in autoheader]
+        for record in data:
+            row = []
+            for fields in all_fields:
+                row.append(extract_from(record, fields))
+            dest.write(sep.join(scientificformat(col, fmt)
+                                for col in row) + u'\n')
+    else:
+        for row in data:
+            dest.write(sep.join(scientificformat(col, fmt)
+                                for col in row) + u'\n')
+    if hasattr(dest, 'getvalue'):
+        return dest.getvalue()[:-1]  # a newline is strangely added
+    else:
+        dest.close()
+    return dest.name
 
 if __name__ == '__main__':  # pretty print of NRML files
     import sys

--- a/openquake/risklib/qa_tests/event_based_test.py
+++ b/openquake/risklib/qa_tests/event_based_test.py
@@ -72,6 +72,8 @@ class EventBasedTestCase(unittest.TestCase):
             insured_losses=False
             )
         wf.riskmodel = mock.MagicMock()
+        # NB: we need a MagicMock since the workflow instance makes a call
+        # self.riskmodel.curve_builders[self.riskmodel.lti[loss_type]]
         out = wf(self.loss_type, assets, gmvs, epsilons, [1, 2, 3, 4, 5])
         numpy.testing.assert_almost_equal(
             out.average_losses, [0.02048617, 0.01940496])

--- a/openquake/risklib/qa_tests/event_based_test.py
+++ b/openquake/risklib/qa_tests/event_based_test.py
@@ -17,6 +17,7 @@
 
 import os
 import unittest
+import mock
 
 import numpy
 
@@ -27,6 +28,7 @@ THISDIR = os.path.dirname(__file__)
 
 gmf = vectors_from_csv('gmf', THISDIR)
 
+# two identical assets
 assets = [workflows.Asset(
           1, 'SOME-TAXONOMY', 1, (0, 0),
           dict(structural=10),
@@ -37,11 +39,6 @@ assets = [workflows.Asset(
 
 class EventBasedTestCase(unittest.TestCase):
     loss_type = 'structural'
-
-    def assert_similar(self, a, b):
-        assert list(a) == list(b), (list(a), list(b))
-        for k in a:
-            self.assertAlmostEqual(a[k], b[k])
 
     def test_mean_based_with_no_correlation(self):
         # This is a regression test. Data has not been checked
@@ -74,15 +71,10 @@ class EventBasedTestCase(unittest.TestCase):
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
             )
+        wf.riskmodel = mock.MagicMock()
         out = wf(self.loss_type, assets, gmvs, epsilons, [1, 2, 3, 4, 5])
-        self.assert_similar(
-            out.event_loss_table,
-            {1: 16.246646231503398,
-             2: 15.613885199116158,
-             3: 15.669704465134854,
-             4: 16.241922530992454,
-             5: 16.010104452203464,
-             })
+        numpy.testing.assert_almost_equal(
+            out.average_losses, [0.02048617, 0.01940496])
 
     def test_mean_based_with_partial_correlation(self):
         # This is a regression test. Data has not been checked
@@ -113,15 +105,10 @@ class EventBasedTestCase(unittest.TestCase):
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
             )
+        wf.riskmodel = mock.MagicMock()
         out = wf(self.loss_type, assets, gmvs, epsilons, [1, 2, 3, 4, 5])
-        self.assert_similar(
-            out.event_loss_table,
-            {1: 15.332714802464356,
-             2: 16.21582466071975,
-             3: 15.646630129345354,
-             4: 15.285164778325353,
-             5: 15.860930792931873,
-             })
+        numpy.testing.assert_almost_equal(
+            out.average_losses, [0.01987912, 0.01929152])
 
     def test_mean_based_with_perfect_correlation(self):
         # This is a regression test. Data has not been checked
@@ -154,15 +141,10 @@ class EventBasedTestCase(unittest.TestCase):
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=False
             )
+        wf.riskmodel = mock.MagicMock()
         out = wf(self.loss_type, assets, gmvs, epsilons, [1, 2, 3, 4, 5])
-        self.assert_similar(
-            out.event_loss_table,
-            {1: 15.232320555463319,
-             2: 16.248173683693864,
-             3: 15.583030510462981,
-             4: 15.177382760499968,
-             5: 15.840499250058254,
-             })
+        numpy.testing.assert_almost_equal(
+            out.average_losses, [0.01952035, 0.01952035])
 
     def test_mean_based(self):
         epsilons = scientific.make_epsilons([gmf[0]], seed=1, correlation=0)
@@ -245,12 +227,9 @@ class EventBasedTestCase(unittest.TestCase):
             conditional_loss_poes=[0.1, 0.5, 0.9],
             insured_losses=True
             )
+        wf.riskmodel = mock.MagicMock()
         out = wf(self.loss_type, assets, gmf[0:2], epsilons, [1, 2, 3, 4, 5])
-        self.assert_similar(
-            out.event_loss_table,
-            {1: 0.20314761658291458,
-             2: 0,
-             3: 0,
-             4: 0,
-             5: 0,
-             })
+        numpy.testing.assert_almost_equal(
+            out.average_losses, [0.00473820568, 0.0047437959417])
+        numpy.testing.assert_almost_equal(
+            out.average_insured_losses, [0, 0])

--- a/openquake/risklib/workflows.py
+++ b/openquake/risklib/workflows.py
@@ -445,7 +445,7 @@ class Classical(Workflow):
         return all_outputs
 
 
-@registry.add('event_based_risk', 'ebr')
+@registry.add('event_based_risk')
 class ProbabilisticEventBased(Workflow):
     """
     Implements the Probabilistic Event Based workflow


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/1841. I have also extended `write_csv` to write on StringIO objects; this is used in the companion PR https://github.com/gem/oq-engine/pull/1839.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/1061/