### PR TITLE
Remove an unwanted ElementTree warning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-[Michele Simionato]
+  [Michele Simionato]
   * Silenced an ElementTree warning
   * Improved the error message for invalid exposures
   * Fixed a few tests on Windows

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-  [Michele Simionato]
+[Michele Simionato]
+  * Silenced an ElementTree warning
   * Improved the error message for invalid exposures
   * Fixed a few tests on Windows
 

--- a/openquake/commonlib/writers.py
+++ b/openquake/commonlib/writers.py
@@ -16,6 +16,7 @@
 import io
 import types
 import logging
+import warnings
 from contextlib import contextmanager
 from xml.sax.saxutils import escape, quoteattr
 
@@ -153,7 +154,10 @@ class StreamingXMLWriter(object):
             tag = self.shorten(node.tag)
         else:
             tag = node.tag
-        if not node and node.text is None:
+        with warnings.catch_warnings():  # unwanted ElementTree warning
+            warnings.simplefilter('ignore')
+            leafnode = not node
+        if leafnode and node.text is None:
             self.emptyElement(tag, node.attrib)
             return
         self.start_tag(tag, node.attrib)

--- a/openquake/commonlib/writers.py
+++ b/openquake/commonlib/writers.py
@@ -157,6 +157,8 @@ class StreamingXMLWriter(object):
         with warnings.catch_warnings():  # unwanted ElementTree warning
             warnings.simplefilter('ignore')
             leafnode = not node
+        # NB: we cannot use len(node) to identify leafs since nodes containing
+        # an iterator have no length. They are always True, even if empty :-(
         if leafnode and node.text is None:
             self.emptyElement(tag, node.attrib)
             return


### PR DESCRIPTION
This was discovered by Marco while exporting hazard curves from the engine. The tests are green:
https://ci.openquake.org/job/zdevel_oq-risklib/1065