### PR TITLE
Better printing of arrays

### DIFF
--- a/openquake/commonlib/commands/show.py
+++ b/openquake/commonlib/commands/show.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import io
 import os
 import shutil
 import logging
@@ -24,6 +25,7 @@ from openquake.commonlib import sap, datastore
 from openquake.baselib.general import humansize
 from openquake.commonlib.oqvalidation import OqParam
 from openquake.commonlib.commands.plot import combined_curves
+from openquake.commonlib.writers import write_csv
 from openquake.commonlib.util import rmsep
 
 
@@ -58,8 +60,8 @@ def show(calc_id, key=None, rlzs=None):
             print(datastore.view(key, ds))
             return
         obj = ds[key]
-        if hasattr(obj, 'value'):
-            print(obj.value)
+        if hasattr(obj, 'value'):  # an array
+            print(write_csv(io.StringIO(), obj.value))
         else:
             print(obj)
         return

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -98,7 +98,9 @@ class RunShowExportTestCase(unittest.TestCase):
 
         with Print.patch() as p:
             show(self.datastore.calc_id, 'sitemesh')
-        self.assertEqual(str(p), '[(0.0, 0.0)]')
+        self.assertEqual(str(p), '''\
+lon:float64:,lat:float64:
+0.00000000E+00,0.00000000E+00''')
 
     def test_export_calc(self):
         tempdir = tempfile.mkdtemp()


### PR DESCRIPTION
Now ``oq-lite show <calc_id> <array_name>`` also prints an header with the column types. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1069