### PR TITLE
Added information about the number of sources and ruptures per TRT in the .rst report

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -124,6 +124,17 @@ def view_rupture_collections(token, dstore):
     return rst_table(rows, ['col', 'smlt_path', 'TRT', 'num_ruptures'])
 
 
+@view.add('ruptures_by_trt')
+def view_ruptures_by_trt(token, dstore):
+    tbl = []
+    header = 'source_model trt_id trt num_sources num_ruptures'.split()
+    for sm in dstore['composite_source_model']:
+        for trt_model in sm.trt_models:
+            tbl.append((sm.name, trt_model.id, trt_model.trt,
+                        len(trt_model.sources), trt_model.num_ruptures))
+    return rst_table(tbl, header=header)
+
+
 @view.add('params')
 def view_params(token, dstore):
     oq = OqParam.from_(dstore.attrs)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
+import numbers
 import operator
 import numpy
 
@@ -128,11 +129,23 @@ def view_rupture_collections(token, dstore):
 def view_ruptures_by_trt(token, dstore):
     tbl = []
     header = 'source_model trt_id trt num_sources num_ruptures'.split()
+    num_trts = 0
+    num_sources = 0
+    num_ruptures = 0
     for sm in dstore['composite_source_model']:
         for trt_model in sm.trt_models:
+            num_trts += 1
+            num_sources += len(trt_model.sources)
+            num_ruptures += trt_model.num_ruptures
             tbl.append((sm.name, trt_model.id, trt_model.trt,
                         len(trt_model.sources), trt_model.num_ruptures))
-    return rst_table(tbl, header=header)
+    rows = [('#TRTs', num_trts), ('#sources', num_sources),
+            ('#num_ruptures', num_ruptures)]
+    if len(rows) > 1:
+        summary = rst_table(rows) + '\n\n'
+    else:
+        summary = ''
+    return summary + rst_table(tbl, header=header)
 
 
 @view.add('params')
@@ -253,9 +266,12 @@ def sum_table(records):
     """
     size = len(records[0])
     result = [None] * size
-    result[0] = 'total'
-    for i in range(1, size):
-        result[i] = sum(rec[i] for rec in records)
+    firstrec = records[0]
+    for i in range(size):
+        if isinstance(firstrec[i], numbers.Number):
+            result[i] = sum(rec[i] for rec in records)
+        else:
+            result[i] = 'total'
     return result
 
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -139,8 +139,8 @@ def view_ruptures_by_trt(token, dstore):
             num_ruptures += trt_model.num_ruptures
             tbl.append((sm.name, trt_model.id, trt_model.trt,
                         len(trt_model.sources), trt_model.num_ruptures))
-    rows = [('#TRTs', num_trts), ('#sources', num_sources),
-            ('#num_ruptures', num_ruptures)]
+    rows = [('#TRT models', num_trts), ('#sources', num_sources),
+            ('#ruptures', num_ruptures)]
     if len(rows) > 1:
         summary = rst_table(rows) + '\n\n'
     else:

--- a/openquake/commonlib/reportwriter.py
+++ b/openquake/commonlib/reportwriter.py
@@ -78,7 +78,7 @@ def build_report(job_ini, output_dir=None):
     if 'num_ruptures' in ds:
         rw.add('rupture_collections')
         rw.add('col_rlz_assocs')
-    else:
+    elif 'scenario' not in oq.calculation_mode:
         rw.add('ruptures_by_trt')
     if oq.calculation_mode in ('classical', 'event_based', 'event_based_risk'):
         rw.add('data_transfer')

--- a/openquake/commonlib/reportwriter.py
+++ b/openquake/commonlib/reportwriter.py
@@ -24,6 +24,7 @@ class ReportWriter(object):
         csm_info='Composite source model',
         rupture_collections='Non-empty rupture collections',
         col_rlz_assocs='Collections <-> realizations',
+        ruptures_by_trt='Number of ruptures per tectonic region type',
         rlzs_assoc='Realizations per (TRT, GSIM)',
         data_transfer='Expected data transfer for the sources'
     )
@@ -77,6 +78,8 @@ def build_report(job_ini, output_dir=None):
     if 'num_ruptures' in ds:
         rw.add('rupture_collections')
         rw.add('col_rlz_assocs')
+    else:
+        rw.add('ruptures_by_trt')
     if oq.calculation_mode in ('classical', 'event_based', 'event_based_risk'):
         rw.add('data_transfer')
     rw.save(report)

--- a/openquake/qa_tests_data/classical/case_1/report.rst
+++ b/openquake/qa_tests_data/classical/case_1/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= =
-#TRTs         1
-#sources      1
-#num_ruptures 1
-============= =
+=========== =
+#TRT models 1
+#sources    1
+#ruptures   1
+=========== =
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_1/report.rst
+++ b/openquake/qa_tests_data/classical/case_1/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= =
+#TRTs         1
+#sources      1
+#num_ruptures 1
+============= =
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_1/report.rst
+++ b/openquake/qa_tests_data/classical/case_1/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   None     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           1           
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        1      
-Estimated sources to send          1.83 KB
+Estimated sources to send          1.87 KB
 Estimated hazard curves to receive 48 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_10/report.rst
+++ b/openquake/qa_tests_data/classical/case_10/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.001
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -48,10 +48,19 @@ Realizations per (TRT, GSIM)
   0,SadighEtAl1997: ['<0,b1_b2,b1,w=0.5>']
   1,SadighEtAl1997: ['<1,b1_b3,b1,w=0.5>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           3000        
+source_model.xml 1      active shallow crust 1           3000        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        2      
-Estimated sources to send          3.73 KB
+Estimated sources to send          3.81 KB
 Estimated hazard curves to receive 64 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_10/report.rst
+++ b/openquake/qa_tests_data/classical/case_10/report.rst
@@ -50,6 +50,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         2   
+#sources      2   
+#num_ruptures 6000
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_10/report.rst
+++ b/openquake/qa_tests_data/classical/case_10/report.rst
@@ -50,11 +50,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         2   
-#sources      2   
-#num_ruptures 6000
-============= ====
+=========== ====
+#TRT models 2   
+#sources    2   
+#ruptures   6000
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_11/report.rst
+++ b/openquake/qa_tests_data/classical/case_11/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.001
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -50,10 +50,20 @@ Realizations per (TRT, GSIM)
   1,SadighEtAl1997: ['<1,b1_b3,b1,w=0.6>']
   2,SadighEtAl1997: ['<2,b1_b4,b1,w=0.2>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           3500        
+source_model.xml 1      active shallow crust 1           3000        
+source_model.xml 2      active shallow crust 1           2500        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        3      
-Estimated sources to send          5.65 KB
+Estimated sources to send          5.79 KB
 Estimated hazard curves to receive 96 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_11/report.rst
+++ b/openquake/qa_tests_data/classical/case_11/report.rst
@@ -52,6 +52,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         3   
+#sources      3   
+#num_ruptures 9000
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_11/report.rst
+++ b/openquake/qa_tests_data/classical/case_11/report.rst
@@ -52,11 +52,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         3   
-#sources      3   
-#num_ruptures 9000
-============= ====
+=========== ====
+#TRT models 3   
+#sources    3   
+#ruptures   9000
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_12/report.rst
+++ b/openquake/qa_tests_data/classical/case_12/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -47,10 +47,19 @@ Realizations per (TRT, GSIM)
   0,SadighEtAl1997: ['<0,b1,b1_b2,w=1.0>']
   1,BooreAtkinson2008: ['<0,b1,b1_b2,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           1           
+source_model.xml 1      stable continental   1           1           
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        2      
-Estimated sources to send          3.83 KB
+Estimated sources to send          3.92 KB
 Estimated hazard curves to receive 48 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_12/report.rst
+++ b/openquake/qa_tests_data/classical/case_12/report.rst
@@ -49,6 +49,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= =
+#TRTs         2
+#sources      2
+#num_ruptures 2
+============= =
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_12/report.rst
+++ b/openquake/qa_tests_data/classical/case_12/report.rst
@@ -49,11 +49,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= =
-#TRTs         2
-#sources      2
-#num_ruptures 2
-============= =
+=========== =
+#TRT models 2
+#sources    2
+#ruptures   2
+=========== =
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_13/report.rst
+++ b/openquake/qa_tests_data/classical/case_13/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.1
 area_source_discretization   10.0     
 random_seed                  23       
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -52,10 +52,19 @@ Realizations per (TRT, GSIM)
   1,BooreAtkinson2008: ['<2,bFault_stitched_D2.1_Char,BooreAtkinson2008,w=0.25>']
   1,ChiouYoungs2008: ['<3,bFault_stitched_D2.1_Char,ChiouYoungs2008,w=0.25>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+============================= ====== ==================== =========== ============
+source_model                  trt_id trt                  num_sources num_ruptures
+============================= ====== ==================== =========== ============
+aFault_aPriori_D2.1.xml       0      Active Shallow Crust 168         1848        
+bFault_stitched_D2.1_Char.xml 1      Active Shallow Crust 186         2046        
+============================= ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
-Number of tasks to generate        33     
-Estimated sources to send          1.27 MB
-Estimated hazard curves to receive 281 KB 
+Number of tasks to generate        72     
+Estimated sources to send          1.36 MB
+Estimated hazard curves to receive 614 KB 
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_13/report.rst
+++ b/openquake/qa_tests_data/classical/case_13/report.rst
@@ -54,6 +54,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         2   
+#sources      354 
+#num_ruptures 3894
+============= ====
+
 ============================= ====== ==================== =========== ============
 source_model                  trt_id trt                  num_sources num_ruptures
 ============================= ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_13/report.rst
+++ b/openquake/qa_tests_data/classical/case_13/report.rst
@@ -54,11 +54,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         2   
-#sources      354 
-#num_ruptures 3894
-============= ====
+=========== ====
+#TRT models 2   
+#sources    354 
+#ruptures   3894
+=========== ====
 
 ============================= ====== ==================== =========== ============
 source_model                  trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_14/report.rst
+++ b/openquake/qa_tests_data/classical/case_14/report.rst
@@ -50,11 +50,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ===
-#TRTs         1  
-#sources      15 
-#num_ruptures 447
-============= ===
+=========== ===
+#TRT models 1  
+#sources    15 
+#ruptures   447
+=========== ===
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_14/report.rst
+++ b/openquake/qa_tests_data/classical/case_14/report.rst
@@ -50,6 +50,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ===
+#TRTs         1  
+#sources      15 
+#num_ruptures 447
+============= ===
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_14/report.rst
+++ b/openquake/qa_tests_data/classical/case_14/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.1
 area_source_discretization   10.0     
 random_seed                  23       
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -48,10 +48,18 @@ Realizations per (TRT, GSIM)
   0,AbrahamsonSilva2008: ['<0,simple_fault,AbrahamsonSilva2008,w=0.5>']
   0,CampbellBozorgnia2008: ['<1,simple_fault,CampbellBozorgnia2008,w=0.5>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+simple_fault.xml 0      Active Shallow Crust 15          447         
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== ========
-Number of tasks to generate        13      
-Estimated sources to send          27.07 KB
-Estimated hazard curves to receive 26 KB   
+Number of tasks to generate        15      
+Estimated sources to send          31.48 KB
+Estimated hazard curves to receive 30 KB   
 ================================== ========

--- a/openquake/qa_tests_data/classical/case_15/report.rst
+++ b/openquake/qa_tests_data/classical/case_15/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.1
 area_source_discretization   10.0     
 random_seed                  23       
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -56,10 +56,21 @@ Realizations per (TRT, GSIM)
   3,BooreAtkinson2008: ['<6,SM2_a3pt2b0pt8,BA2008_@,w=0.125>']
   3,CampbellBozorgnia2008: ['<7,SM2_a3pt2b0pt8,CB2008_@,w=0.125>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================== ====== ======================== =========== ============
+source_model       trt_id trt                      num_sources num_ruptures
+================== ====== ======================== =========== ============
+source_model_1.xml 0      Active Shallow Crust     1           15          
+source_model_1.xml 1      Stable Continental Crust 1           15          
+source_model_2.xml 2      Active Shallow Crust     16          240         
+source_model_2.xml 3      Active Shallow Crust     16          240         
+================== ====== ======================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== ========
 Number of tasks to generate        18      
-Estimated sources to send          43.64 KB
+Estimated sources to send          44.85 KB
 Estimated hazard curves to receive 13 KB   
 ================================== ========

--- a/openquake/qa_tests_data/classical/case_15/report.rst
+++ b/openquake/qa_tests_data/classical/case_15/report.rst
@@ -58,6 +58,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ===
+#TRTs         4  
+#sources      34 
+#num_ruptures 510
+============= ===
+
 ================== ====== ======================== =========== ============
 source_model       trt_id trt                      num_sources num_ruptures
 ================== ====== ======================== =========== ============

--- a/openquake/qa_tests_data/classical/case_15/report.rst
+++ b/openquake/qa_tests_data/classical/case_15/report.rst
@@ -58,11 +58,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ===
-#TRTs         4  
-#sources      34 
-#num_ruptures 510
-============= ===
+=========== ===
+#TRT models 4  
+#sources    34 
+#ruptures   510
+=========== ===
 
 ================== ====== ======================== =========== ============
 source_model       trt_id trt                      num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_16/report.rst
+++ b/openquake/qa_tests_data/classical/case_16/report.rst
@@ -66,6 +66,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= =====
+#TRTs         10   
+#sources      1350 
+#num_ruptures 20260
+============= =====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_16/report.rst
+++ b/openquake/qa_tests_data/classical/case_16/report.rst
@@ -66,11 +66,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= =====
-#TRTs         10   
-#sources      1350 
-#num_ruptures 20260
-============= =====
+=========== =====
+#TRT models 10   
+#sources    1350 
+#ruptures   20260
+=========== =====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_16/report.rst
+++ b/openquake/qa_tests_data/classical/case_16/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.1
 area_source_discretization   10.0     
 random_seed                  23       
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -64,10 +64,27 @@ Realizations per (TRT, GSIM)
   8,BooreAtkinson2008: ['<8,b11_b24_b32_b41_b51_b62_b71_b84_b93_b101_b111,b11,w=0.1>']
   9,BooreAtkinson2008: ['<9,b11_b24_b33_b40_b52_b62_b72_b81_b91_b102_b112,b11,w=0.1>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      Active Shallow Crust 135         1925        
+source_model.xml 1      Active Shallow Crust 135         2025        
+source_model.xml 2      Active Shallow Crust 135         2135        
+source_model.xml 3      Active Shallow Crust 135         2035        
+source_model.xml 4      Active Shallow Crust 135         1865        
+source_model.xml 5      Active Shallow Crust 135         2085        
+source_model.xml 6      Active Shallow Crust 135         2075        
+source_model.xml 7      Active Shallow Crust 135         2185        
+source_model.xml 8      Active Shallow Crust 135         1905        
+source_model.xml 9      Active Shallow Crust 135         2025        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
-================================== ========
-Number of tasks to generate        38      
-Estimated sources to send          360.2 KB
-Estimated hazard curves to receive 912 B   
-================================== ========
+================================== =========
+Number of tasks to generate        70       
+Estimated sources to send          409.71 KB
+Estimated hazard curves to receive 1 KB     
+================================== =========

--- a/openquake/qa_tests_data/classical/case_17/report.rst
+++ b/openquake/qa_tests_data/classical/case_17/report.rst
@@ -51,11 +51,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ==
-#TRTs         2 
-#sources      2 
-#num_ruptures 46
-============= ==
+=========== ==
+#TRT models 2 
+#sources    2 
+#ruptures   46
+=========== ==
 
 ================== ====== ==================== =========== ============
 source_model       trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_17/report.rst
+++ b/openquake/qa_tests_data/classical/case_17/report.rst
@@ -51,6 +51,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ==
+#TRTs         2 
+#sources      2 
+#num_ruptures 46
+============= ==
+
 ================== ====== ==================== =========== ============
 source_model       trt_id trt                  num_sources num_ruptures
 ================== ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_17/report.rst
+++ b/openquake/qa_tests_data/classical/case_17/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  106      
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -49,10 +49,19 @@ Realizations per (TRT, GSIM)
   0,SadighEtAl1997: ['<0,b1,b1,w=0.2>']
   1,SadighEtAl1997: ['<1,b2,b1,w=0.2>', '<2,b2,b1,w=0.2>', '<3,b2,b1,w=0.2>', '<4,b2,b1,w=0.2>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================== ====== ==================== =========== ============
+source_model       trt_id trt                  num_sources num_ruptures
+================== ====== ==================== =========== ============
+source_model_1.xml 0      active shallow crust 1           39          
+source_model_2.xml 1      active shallow crust 1           7           
+================== ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        2      
-Estimated sources to send          3.98 KB
+Estimated sources to send          4.07 KB
 Estimated hazard curves to receive 48 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_19/report.rst
+++ b/openquake/qa_tests_data/classical/case_19/report.rst
@@ -51,6 +51,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         5   
+#sources      370 
+#num_ruptures 7770
+============= ====
+
 ============================ ====== ==================== =========== ============
 source_model                 trt_id trt                  num_sources num_ruptures
 ============================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_19/report.rst
+++ b/openquake/qa_tests_data/classical/case_19/report.rst
@@ -51,11 +51,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         5   
-#sources      370 
-#num_ruptures 7770
-============= ====
+=========== ====
+#TRT models 5   
+#sources    370 
+#ruptures   7770
+=========== ====
 
 ============================ ====== ==================== =========== ============
 source_model                 trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_19/report.rst
+++ b/openquake/qa_tests_data/classical/case_19/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.2
 area_source_discretization   10.0     
 random_seed                  23       
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -49,10 +49,22 @@ Realizations per (TRT, GSIM)
   4,YoungsEtAl1997SSlab: ['<2,b1,@_@_@_@_b53_@_@,w=0.2>']
   4,ZhaoEtAl2006SSlab: ['<3,b1,@_@_@_@_b54_@_@,w=0.4>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+============================ ====== ==================== =========== ============
+source_model                 trt_id trt                  num_sources num_ruptures
+============================ ====== ==================== =========== ============
+simple_area_source_model.xml 0      Subduction Interface 0           0           
+simple_area_source_model.xml 1      Volcanic             0           0           
+simple_area_source_model.xml 2      Shield               0           0           
+simple_area_source_model.xml 3      Stable Shallow Crust 0           0           
+simple_area_source_model.xml 4      Subduction Inslab    370         7770        
+============================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =========
-Number of tasks to generate        29       
-Estimated sources to send          132.37 KB
-Estimated hazard curves to receive 70 KB    
+Number of tasks to generate        53       
+Estimated sources to send          186.14 KB
+Estimated hazard curves to receive 129 KB   
 ================================== =========

--- a/openquake/qa_tests_data/classical/case_2/report.rst
+++ b/openquake/qa_tests_data/classical/case_2/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.001
 area_source_discretization   None     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           3000        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        1      
-Estimated sources to send          1.84 KB
+Estimated sources to send          1.88 KB
 Estimated hazard curves to receive 32 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_2/report.rst
+++ b/openquake/qa_tests_data/classical/case_2/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         1   
-#sources      1   
-#num_ruptures 3000
-============= ====
+=========== ====
+#TRT models 1   
+#sources    1   
+#ruptures   3000
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_2/report.rst
+++ b/openquake/qa_tests_data/classical/case_2/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         1   
+#sources      1   
+#num_ruptures 3000
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_3/report.rst
+++ b/openquake/qa_tests_data/classical/case_3/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= =====
-#TRTs         1    
-#sources      31353
-#num_ruptures 31353
-============= =====
+=========== =====
+#TRT models 1    
+#sources    31353
+#ruptures   31353
+=========== =====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_3/report.rst
+++ b/openquake/qa_tests_data/classical/case_3/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= =====
+#TRTs         1    
+#sources      31353
+#num_ruptures 31353
+============= =====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_3/report.rst
+++ b/openquake/qa_tests_data/classical/case_3/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   0.05     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 31353       31353       
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
-Number of tasks to generate        32     
-Estimated sources to send          6.83 MB
-Estimated hazard curves to receive 768 B  
+Number of tasks to generate        61     
+Estimated sources to send          6.87 MB
+Estimated hazard curves to receive 1 KB   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_4/report.rst
+++ b/openquake/qa_tests_data/classical/case_4/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           901         
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        1      
-Estimated sources to send          1.75 KB
+Estimated sources to send          1.79 KB
 Estimated hazard curves to receive 24 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_4/report.rst
+++ b/openquake/qa_tests_data/classical/case_4/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ===
-#TRTs         1  
-#sources      1  
-#num_ruptures 901
-============= ===
+=========== ===
+#TRT models 1  
+#sources    1  
+#ruptures   901
+=========== ===
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_4/report.rst
+++ b/openquake/qa_tests_data/classical/case_4/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ===
+#TRTs         1  
+#sources      1  
+#num_ruptures 901
+============= ===
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_5/report.rst
+++ b/openquake/qa_tests_data/classical/case_5/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ===
+#TRTs         1  
+#sources      1  
+#num_ruptures 485
+============= ===
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_5/report.rst
+++ b/openquake/qa_tests_data/classical/case_5/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ===
-#TRTs         1  
-#sources      1  
-#num_ruptures 485
-============= ===
+=========== ===
+#TRT models 1  
+#sources    1  
+#ruptures   485
+=========== ===
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_5/report.rst
+++ b/openquake/qa_tests_data/classical/case_5/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           485         
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        1      
-Estimated sources to send          1.83 KB
+Estimated sources to send          1.87 KB
 Estimated hazard curves to receive 24 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_6/report.rst
+++ b/openquake/qa_tests_data/classical/case_6/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -46,10 +46,18 @@ Realizations per (TRT, GSIM)
   <RlzsAssoc(1)
   0,SadighEtAl1997: ['<0,b1,b1,w=1.0>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 2           1386        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        2      
-Estimated sources to send          3.58 KB
+Estimated sources to send          3.66 KB
 Estimated hazard curves to receive 48 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_6/report.rst
+++ b/openquake/qa_tests_data/classical/case_6/report.rst
@@ -48,11 +48,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         1   
-#sources      2   
-#num_ruptures 1386
-============= ====
+=========== ====
+#TRT models 1   
+#sources    2   
+#ruptures   1386
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_6/report.rst
+++ b/openquake/qa_tests_data/classical/case_6/report.rst
@@ -48,6 +48,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         1   
+#sources      2   
+#num_ruptures 1386
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_7/report.rst
+++ b/openquake/qa_tests_data/classical/case_7/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             1.0
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -49,10 +49,19 @@ Realizations per (TRT, GSIM)
   0,SadighEtAl1997: ['<0,b1,b1,w=0.7>']
   1,SadighEtAl1997: ['<1,b2,b1,w=0.3>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================== ====== ==================== =========== ============
+source_model       trt_id trt                  num_sources num_ruptures
+================== ====== ==================== =========== ============
+source_model_1.xml 0      active shallow crust 2           1386        
+source_model_2.xml 1      active shallow crust 1           901         
+================== ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        3      
-Estimated sources to send          5.39 KB
+Estimated sources to send          5.52 KB
 Estimated hazard curves to receive 72 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_7/report.rst
+++ b/openquake/qa_tests_data/classical/case_7/report.rst
@@ -51,6 +51,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         2   
+#sources      3   
+#num_ruptures 2287
+============= ====
+
 ================== ====== ==================== =========== ============
 source_model       trt_id trt                  num_sources num_ruptures
 ================== ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_7/report.rst
+++ b/openquake/qa_tests_data/classical/case_7/report.rst
@@ -51,11 +51,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         2   
-#sources      3   
-#num_ruptures 2287
-============= ====
+=========== ====
+#TRT models 2   
+#sources    3   
+#ruptures   2287
+=========== ====
 
 ================== ====== ==================== =========== ============
 source_model       trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_8/report.rst
+++ b/openquake/qa_tests_data/classical/case_8/report.rst
@@ -52,6 +52,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         3   
+#sources      3   
+#num_ruptures 9000
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_8/report.rst
+++ b/openquake/qa_tests_data/classical/case_8/report.rst
@@ -52,11 +52,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         3   
-#sources      3   
-#num_ruptures 9000
-============= ====
+=========== ====
+#TRT models 3   
+#sources    3   
+#ruptures   9000
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/classical/case_8/report.rst
+++ b/openquake/qa_tests_data/classical/case_8/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.001
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -50,10 +50,20 @@ Realizations per (TRT, GSIM)
   1,SadighEtAl1997: ['<1,b1_b3,b1,w=0.3>']
   2,SadighEtAl1997: ['<2,b1_b4,b1,w=0.4>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           3000        
+source_model.xml 1      active shallow crust 1           3000        
+source_model.xml 2      active shallow crust 1           3000        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        3      
-Estimated sources to send          5.65 KB
+Estimated sources to send          5.79 KB
 Estimated hazard curves to receive 96 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_9/report.rst
+++ b/openquake/qa_tests_data/classical/case_9/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             0.001
 area_source_discretization   10.0     
 random_seed                  1066     
 master_seed                  0        
-concurrent_tasks             32       
+concurrent_tasks             64       
 ============================ =========
 
 Input files
@@ -48,10 +48,19 @@ Realizations per (TRT, GSIM)
   0,SadighEtAl1997: ['<0,b1_b2,b1,w=0.5>']
   1,SadighEtAl1997: ['<1,b1_b3,b1,w=0.5>']>
 
+Number of ruptures per tectonic region type
+-------------------------------------------
+================ ====== ==================== =========== ============
+source_model     trt_id trt                  num_sources num_ruptures
+================ ====== ==================== =========== ============
+source_model.xml 0      active shallow crust 1           3000        
+source_model.xml 1      active shallow crust 1           3500        
+================ ====== ==================== =========== ============
+
 Expected data transfer for the sources
 --------------------------------------
 ================================== =======
 Number of tasks to generate        2      
-Estimated sources to send          3.73 KB
+Estimated sources to send          3.81 KB
 Estimated hazard curves to receive 64 B   
 ================================== =======

--- a/openquake/qa_tests_data/classical/case_9/report.rst
+++ b/openquake/qa_tests_data/classical/case_9/report.rst
@@ -50,6 +50,12 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
+============= ====
+#TRTs         2   
+#sources      2   
+#num_ruptures 6500
+============= ====
+
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures
 ================ ====== ==================== =========== ============

--- a/openquake/qa_tests_data/classical/case_9/report.rst
+++ b/openquake/qa_tests_data/classical/case_9/report.rst
@@ -50,11 +50,11 @@ Realizations per (TRT, GSIM)
 
 Number of ruptures per tectonic region type
 -------------------------------------------
-============= ====
-#TRTs         2   
-#sources      2   
-#num_ruptures 6500
-============= ====
+=========== ====
+#TRT models 2   
+#sources    2   
+#ruptures   6500
+=========== ====
 
 ================ ====== ==================== =========== ============
 source_model     trt_id trt                  num_sources num_ruptures

--- a/openquake/qa_tests_data/scenario/case_1/report.rst
+++ b/openquake/qa_tests_data/scenario/case_1/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_2/report.rst
+++ b/openquake/qa_tests_data/scenario/case_2/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_3/report.rst
+++ b/openquake/qa_tests_data/scenario/case_3/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_4/report.rst
+++ b/openquake/qa_tests_data/scenario/case_4/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_5/report.rst
+++ b/openquake/qa_tests_data/scenario/case_5/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_6/report.rst
+++ b/openquake/qa_tests_data/scenario/case_6/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_7/report.rst
+++ b/openquake/qa_tests_data/scenario/case_7/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_8/report.rst
+++ b/openquake/qa_tests_data/scenario/case_8/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files

--- a/openquake/qa_tests_data/scenario/case_9/report.rst
+++ b/openquake/qa_tests_data/scenario/case_9/report.rst
@@ -16,7 +16,7 @@ width_of_mfd_bin             None
 area_source_discretization   None    
 random_seed                  3       
 master_seed                  0       
-concurrent_tasks             32      
+concurrent_tasks             64      
 ============================ ========
 
 Input files


### PR DESCRIPTION
Closes https://bugs.launchpad.net/oq-engine/+bug/1467940.
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/1110