### PR TITLE
Closing the datastore between a test and the other

### DIFF
--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -78,6 +78,7 @@ class CalculatorTestCase(unittest.TestCase):
             self.calc = self.get_calc(
                 testfile, inis[1], hazard_calculation_id=hc_id, **kw)
             result.update(self.calc.run())
+        self.calc.datastore.close()
         return result
 
     def execute(self, testfile, job_ini):

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -243,7 +243,10 @@ class DataStore(collections.MutableMapping):
 
     def close(self):
         """Close the underlying hdf5 file"""
-        self.hdf5.close()
+        if self.parent:
+            self.parent.close()
+        if self.hdf5:  # is open
+            self.hdf5.close()
 
     def clear(self):
         """Remove the datastore from the file system"""


### PR DESCRIPTION
The tests are green: https://ci.openquake.org/job/zdevel_oq-risklib/1130.
See also the last comment to https://github.com/gem/oq-engine/issues/1870