### PR TITLE
Set the correct EventBasedRiskCalculator.pre_calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,5 @@
   [Michele Simionato]
-  * Added support for multiple versions of NRML for fragility and
-    vulnerability functions and deprecated NRML 0.4
+  * Added support for NRML 0.5 for fragility functions and deprecated NRML 0.4
   * Added a ConsequenceModel parser and implemented the calculation of
     consequences in the scenario_damage calculator
 

--- a/demos/ProbabilisticEventBased/job_risk.ini
+++ b/demos/ProbabilisticEventBased/job_risk.ini
@@ -59,7 +59,7 @@ ses_per_logic_tree_path = 200
 [output]
 
 export_dir = /tmp
-ground_motion_fields = true
+ground_motion_fields = false
 hazard_curves_from_gmfs = true
 mean_hazard_curves = true
 quantile_hazard_curves =

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
 import abc
 import pdb

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -322,18 +322,6 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         #         'rcurves-rlzs' in self.datastore):
         #     self.build_loss_maps()
 
-    def clean_up(self):
-        """
-        Final checks and cleanup
-        """
-        if (self.oqparam.ground_motion_fields and
-                'gmf_by_trt_gsim' not in self.datastore):
-            logging.warn(
-                'Even if the flag `ground_motion_fields` was set the GMFs '
-                'were not saved.\nYou should use the event_based hazard '
-                'calculator to do that, not the risk one')
-        super(EventBasedRiskCalculator, self).clean_up()
-
     def build_specific_loss_curves(self, group, kind='loss'):
         ses_ratio = self.oqparam.ses_ratio
         assetcol = self.assetcol[self.spec_indices]

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -23,7 +23,7 @@ import collections
 import numpy
 
 from openquake.baselib.general import AccumDict, humansize
-from openquake.calculators import base, event_based
+from openquake.calculators import base
 from openquake.commonlib import readinput, parallel, datastore
 from openquake.risklib import riskinput, scientific
 from openquake.commonlib.parallel import apply_reduce

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -23,7 +23,7 @@ import collections
 import numpy
 
 from openquake.baselib.general import AccumDict, humansize
-from openquake.calculators import base
+from openquake.calculators import base, event_based
 from openquake.commonlib import readinput, parallel, datastore
 from openquake.risklib import riskinput, scientific
 from openquake.commonlib.parallel import apply_reduce
@@ -151,7 +151,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
     Event based PSHA calculator generating the event loss table and
     fixed ratios loss curves.
     """
-    pre_calculator = 'event_based_rupture'
+    pre_calculator = 'event_based'
     core_func = event_based_risk
 
     epsilon_matrix = datastore.persistent_attribute('epsilon_matrix')


### PR DESCRIPTION
As it was before, we were not computing the hazard curves, even if hazard_curves_from_gmfs was set.