### PR TITLE
Switched to setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ install:
   - pip install http://ftp.openquake.org/python-wheels/Shapely-1.5.9-py2-none-any.whl
   - pip install http://ftp.openquake.org/python-wheels/h5py-2.5.0-cp27-none-linux_x86_64.whl
   - pip install https://github.com/gem/oq-hazardlib/archive/master.zip
-  - python setup.py develop
 
 script:
-  - find . -name \*_test.py| parallel 'nosetests -xv -a"!slow"'
+  - python setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pip install http://ftp.openquake.org/python-wheels/scipy-0.16.0-cp27-none-linux_x86_64.whl
   - pip install http://ftp.openquake.org/python-wheels/Cython-0.22.1-cp27-none-linux_x86_64.whl
   - pip install http://ftp.openquake.org/python-wheels/Shapely-1.5.9-py2-none-any.whl
-  - pip install http://ftp.openquake.org/python-wheels/h5py-2.5.0-cp27-none-linux_x86_64.whl
+  - pip install http://ftp.openquake.org/python-wheels/h5py-2.2.1-cp27-none-linux_x86_64.whl
   - pip install https://github.com/gem/oq-hazardlib/archive/master.zip
 
 script:

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -181,8 +181,8 @@ class SourceModelLogicTreeBrokenInputTestCase(unittest.TestCase):
 
     # FIXME: the logic tree validation must be rewritten
     # see https://bugs.launchpad.net/oq-engine/+bug/1323916
-    @unittest.skip
     def test_logictree_schema_violation(self):
+        raise unittest.SkipTest
         source = _make_nrml("""\
             <logicTreeSet>
                 <logicTree logicTreeID="lt1"/>
@@ -498,8 +498,8 @@ class SourceModelLogicTreeBrokenInputTestCase(unittest.TestCase):
 
     # FIXME: the logic tree validation must be rewritten
     # see https://bugs.launchpad.net/oq-engine/+bug/1323916
-    @unittest.skip
     def test_source_model_schema_violation(self):
+        raise unittest.SkipTest
         lt = _make_nrml("""\
             <logicTree logicTreeID="lt1">
               <logicTreeBranchingLevel branchingLevelID="bl1">

--- a/openquake/commonlib/tests/risk_parsers_test.py
+++ b/openquake/commonlib/tests/risk_parsers_test.py
@@ -31,19 +31,6 @@ def get_example(fname):
 
 class ExposureModelParserTestCase(unittest.TestCase):
 
-    @unittest.skip
-    def test_schema_validation(self):
-        invalid_exposure = """\
-<?xml version='1.0' encoding='utf-8'?>
-  <nrml xmlns:gml="http://www.opengis.net/gml"
-    xmlns="http://openquake.org/xmlns/nrml/0.4">
-    <exposureModel id="ep1"/>
-</nrml>
-"""
-
-        self.assertRaises(InvalidFile, parsers.ExposureModelParser,
-                          io.BytesIO(invalid_exposure))
-
     def test_parsing(self):
         exposure = """\
 <?xml version='1.0' encoding='utf-8'?>

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
     namespace_packages=['openquake'],
     include_package_data=True,
     test_loader='openquake.baselib.runtests:TestLoader',
-    test_suite='openquake.risklib,openquake.commonlib',
+    test_suite='openquake.risklib,openquake.commonlib,openquake.calculators',
     zip_safe=False,
 )


### PR DESCRIPTION
The advantage is that we can customize how the tests are run. Moreover a lot of warnings that were hidden by nose are now visible.
I have also changed the h5py wheel to version 2.2.1 and now the segmentation fault has disappeared!