### PR TITLE
Reduced the memory consumption in the event based risk calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Improved the memory consumption and data transfer of the event_based_risk
+    calculator
   * The ProbabilisticEventBased risk demo works with a single job.ini
   * Added support for NRML 0.5 for fragility functions and deprecated NRML 0.4
   * Added a ConsequenceModel parser and implemented the calculation of

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -145,6 +145,10 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
                 result[idx] = [sum(lst, AccumDict())]
         else:
             result[idx] = []
+
+    # NB: don't return back large amounts of data
+    delattr(monitor, 'assets_by_site')
+    delattr(monitor, 'eps_dict')
     return result
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -56,7 +56,8 @@ def cube(O, L, R, factory):
 
 
 @parallel.litetask
-def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
+def event_based_risk(riskinputs, riskmodel, rlzs_assoc, assets_by_site,
+                     eps_dict, specific_assets, monitor):
     """
     :param riskinputs:
         a list of :class:`openquake.risklib.riskinput.RiskInput` objects
@@ -64,6 +65,12 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
         a :class:`openquake.risklib.riskinput.RiskModel` instance
     :param rlzs_assoc:
         a class:`openquake.commonlib.source.RlzsAssoc` instance
+    :param assets_by_site:
+        a representation of the exposure
+    :param eps_dict:
+        a dictionary with the epsilons per asset
+    :param specific_assets:
+        .ini file parameter
     :param monitor:
         :class:`openquake.baselib.performance.PerformanceMonitor` instance
     :returns:
@@ -72,12 +79,12 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
     """
     lti = riskmodel.lti  # loss type -> index
     L, R = len(lti), len(rlzs_assoc.realizations)
-    specific_assets = monitor.oqparam.specific_assets
     result = cube(monitor.num_outputs, L, R, list)
     for l in range(L):
         for r in range(R):
             result[AVGLOSS, l, r] = numpy.zeros((monitor.num_assets, 2))
-    for out_by_rlz in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
+    for out_by_rlz in riskmodel.gen_outputs(
+            riskinputs, rlzs_assoc, monitor, assets_by_site, eps_dict):
         rup_slice = out_by_rlz.rup_slice
         rup_ids = list(range(rup_slice.start, rup_slice.stop))
         for out in out_by_rlz:
@@ -145,10 +152,6 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
                 result[idx] = [sum(lst, AccumDict())]
         else:
             result[idx] = []
-
-    # NB: don't return back large amounts of data
-    delattr(monitor, 'assets_by_site')
-    delattr(monitor, 'eps_dict')
     return result
 
 
@@ -198,6 +201,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         eps_dict = riskinput.make_eps_dict(
             assets_by_site, num_samples, oq.master_seed, oq.asset_correlation)
         logging.info('Generated %d epsilons', num_samples * len(eps_dict))
+        self.eps_dict = eps_dict
         self.epsilon_matrix = numpy.array(
             [eps_dict[a['asset_ref']] for a in self.assetcol])
         self.riskinputs = list(self.riskmodel.build_inputs_from_ruptures(
@@ -215,9 +219,6 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         self.monitor.oqparam = self.oqparam
         # ugly: attaching an attribute needed in the task function
         self.monitor.num_outputs = len(self.outs)
-        # attaching two other attributes used in riskinput.gen_outputs
-        self.monitor.assets_by_site = self.assets_by_site
-        self.monitor.eps_dict = eps_dict
         self.monitor.num_assets = N = self.count_assets()
         for o, out in enumerate(self.outs):
             self.datastore.hdf5.create_group(out)
@@ -249,7 +250,9 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         """
         return apply_reduce(
             self.core_func.__func__,
-            (self.riskinputs, self.riskmodel, self.rlzs_assoc, self.monitor),
+            (self.riskinputs, self.riskmodel, self.rlzs_assoc,
+             self.assets_by_site, self.eps_dict,
+             self.oqparam.specific_assets, self.monitor),
             concurrent_tasks=self.oqparam.concurrent_tasks,
             agg=self.agg,
             acc=cube(self.monitor.num_outputs, self.L, self.R, list),

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -104,14 +104,14 @@ def safely_call(func, args, pickle=False):
     """
     if pickle:
         args = [a.unpickle() for a in args]
-    mon = args and isinstance(args[-1], PerformanceMonitor)
+    ismon = args and isinstance(args[-1], PerformanceMonitor)
+    mon = args[-1] if ismon else DummyMonitor()
     try:
-        res = func(*args), None, args[-1] if mon else DummyMonitor()
+        res = func(*args), None, mon
     except:
         etype, exc, tb = sys.exc_info()
         tb_str = ''.join(traceback.format_tb(tb))
-        res = ('\n%s%s: %s' % (tb_str, etype.__name__, exc), etype,
-               args[-1] if mon else DummyMonitor())
+        res = ('\n%s%s: %s' % (tb_str, etype.__name__, exc), etype, mon)
     if pickle:
         return Pickled(res)
     return res

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -31,6 +31,7 @@ import psutil
 
 from openquake.baselib.python3compat import pickle
 from openquake.baselib.performance import PerformanceMonitor, DummyMonitor
+from openquake.baselib.general import split_in_blocks, AccumDict, humansize
 
 
 if psutil.__version__ > '2.0.0':  # Ubuntu 14.10
@@ -53,9 +54,6 @@ else:  # Ubuntu 12.04
 
     def memory_info(proc):
         return proc.get_memory_info()
-
-
-from openquake.baselib.general import split_in_blocks, AccumDict, humansize
 
 
 executor = ProcessPoolExecutor()

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -220,7 +220,8 @@ class RiskModel(collections.Mapping):
                 slice(rup_start, rup_stop))
             rup_start = rup_stop
 
-    def gen_outputs(self, riskinputs, rlzs_assoc, monitor):
+    def gen_outputs(self, riskinputs, rlzs_assoc, monitor,
+                    assets_by_site=None, eps_dict=None):
         """
         Group the assets per taxonomy and compute the outputs by using the
         underlying workflows. Yield the outputs generated as dictionaries
@@ -232,15 +233,10 @@ class RiskModel(collections.Mapping):
         """
         mon_hazard = monitor('getting hazard')
         mon_risk = monitor('computing individual risk')
+        eps_dict = eps_dict or {}
         for riskinput in riskinputs:
-            try:
-                assets_by_site = riskinput.assets_by_site
-            except AttributeError:  # for event_based_risk
-                assets_by_site = monitor.assets_by_site
-            try:
-                eps_dict = monitor.eps_dict
-            except AttributeError:
-                eps_dict = {}
+            assets_by_site = getattr(
+                riskinput, 'assets_by_site', assets_by_site)
             with mon_hazard:
                 # get assets, hazards, epsilons
                 a, h, e = riskinput.get_all(


### PR DESCRIPTION
Aggregating by array instead that by list of arrays. In our demo the improvement is from ~900 KB per task to ~300 KB per task (pickled size of the task result). Moreover, I am reducing the data transfer back by removing big attributes from the monitor. The difference is from ~73 MB to ~300 KB per task.
Closes https://github.com/gem/oq-risklib/issues/451