### PR TITLE
Adds "incrementalMFDAbsolute" option to source model logic tree

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -380,10 +380,6 @@ class BranchSet(object):
             # source didn't pass the filter
             return
 
-        #if not isinstance(source.mfd, openquake.hazardlib.mfd.TruncatedGRMFD):
-            # source's mfd is not gutenberg-richter
-        #    return
-
         self._apply_uncertainty_to_mfd(source.mfd, value)
 
     def _apply_uncertainty_to_mfd(self, mfd, value):
@@ -402,6 +398,7 @@ class BranchSet(object):
 
         elif self.uncertainty_type == 'maxMagGRAbsolute':
             mfd.modify('set_max_mag', dict(value=value))
+
         elif self.uncertainty_type == 'incrementalMFDAbsolute':
             min_mag, bin_width, occur_rates = value
             mfd.modify('set_mfd', dict(min_mag=min_mag, bin_width=bin_width,

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -801,8 +801,8 @@ class SourceModelLogicTree(BaseLogicTree):
             if len(mbr) == 3:
                 min_mag, bin_width, rates = mbr
                 try:
-                    rates = positivefloats(rates)
-                except:
+                    rates = valid.positivefloats(rates)
+                except ValueError:
                     rates = []
                 if _float_re.match(min_mag) and _float_re.match(bin_width) and\
                         len(rates):

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -801,11 +801,11 @@ class SourceModelLogicTree(BaseLogicTree):
             if len(mbr) == 3:
                 min_mag, bin_width, rates = mbr
                 try:
-                    rates = positivefloat(rates)
+                    rates = positivefloats(rates)
                 except:
                     rates = []
                 if _float_re.match(min_mag) and _float_re.match(bin_width) and\
-                    len(rates):
+                        len(rates):
                     return
             raise ValidationError(
                 node, self.filename,

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -380,9 +380,9 @@ class BranchSet(object):
             # source didn't pass the filter
             return
 
-        if not isinstance(source.mfd, openquake.hazardlib.mfd.TruncatedGRMFD):
+        #if not isinstance(source.mfd, openquake.hazardlib.mfd.TruncatedGRMFD):
             # source's mfd is not gutenberg-richter
-            return
+        #    return
 
         self._apply_uncertainty_to_mfd(source.mfd, value)
 
@@ -402,7 +402,10 @@ class BranchSet(object):
 
         elif self.uncertainty_type == 'maxMagGRAbsolute':
             mfd.modify('set_max_mag', dict(value=value))
-
+        elif self.uncertainty_type == 'incrementalMFDAbsolute':
+            min_mag, bin_width, occur_rates = value
+            mfd.modify('set_mfd', dict(min_mag=min_mag, bin_width=bin_width,
+                                       occurrence_rates=occur_rates))
         else:
             raise AssertionError('unknown uncertainty type %r'
                                  % self.uncertainty_type)
@@ -759,6 +762,10 @@ class SourceModelLogicTree(BaseLogicTree):
         elif branchset.uncertainty_type == 'abGRAbsolute':
             [a, b] = value.strip().split()
             return float(a), float(b)
+        elif branchset.uncertainty_type == 'incrementalMFDAbsolute':
+            min_mag, bin_width, rates = value.strip().split(',')
+            return float(min_mag), float(bin_width),\
+                valid.positivefloats(rates)
         else:
             return float(value)
 
@@ -791,6 +798,21 @@ class SourceModelLogicTree(BaseLogicTree):
             raise ValidationError(
                 node, self.filename,
                 'expected a pair of floats separated by space'
+            )
+        elif branchset.uncertainty_type == 'incrementalMFDAbsolute':
+            mbr = value.split(',')
+            if len(mbr) == 3:
+                min_mag, bin_width, rates = mbr
+                try:
+                    rates = positivefloat(rates)
+                except:
+                    rates = []
+                if _float_re.match(min_mag) and _float_re.match(bin_width) and\
+                    len(rates):
+                    return
+            raise ValidationError(
+                node, self.filename,
+                'expected mfd in the form min_mag,bin_width,rate_1 rate_2 ...'
             )
         else:
             if not _float_re.match(value):

--- a/openquake/commonlib/nrml_examples/logic-tree-source-model.xml
+++ b/openquake/commonlib/nrml_examples/logic-tree-source-model.xml
@@ -55,6 +55,25 @@
                 </logicTreeBranch>
             </logicTreeBranchSet>
         </logicTreeBranchingLevel>
+        
+        <logicTreeBranchingLevel branchingLevelID="bl4">
+            <logicTreeBranchSet uncertaintyType="incrementalMFDAbsolute" branchSetID="bs4">
+                <logicTreeBranch branchID="b9">
+                    <uncertaintyModel>8.0,0.1,0.005 0.0025</uncertaintyModel>
+                    <uncertaintyWeight>0.33</uncertaintyWeight>
+                </logicTreeBranch>
+
+                <logicTreeBranch branchID="b10">
+                    <uncertaintyModel>8.0,0.1,0.01 0.005</uncertaintyModel>
+                    <uncertaintyWeight>0.34</uncertaintyWeight>
+                </logicTreeBranch>
+
+                <logicTreeBranch branchID="b11">
+                    <uncertaintyModel>8.0,0.1,0.05 0.025</uncertaintyModel>
+                    <uncertaintyWeight>0.33</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/openquake/commonlib/tests/data/example-source-model-logictree.xml
+++ b/openquake/commonlib/tests/data/example-source-model-logictree.xml
@@ -49,6 +49,5 @@
                 </logicTreeBranch>
             </logicTreeBranchSet>
         </logicTreeBranchingLevel>
-
     </logicTree>
 </nrml>

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1220,8 +1220,6 @@ class BranchSetApplyUncertaintyMethodSignaturesTestCase(unittest.TestCase):
                                      'occurrence_rates': [0.01, 0.005]}),  {})]
         )
 
-    
-
     def test_apply_uncertainty_unknown_uncertainty_type(self):
         bs = logictree.BranchSet('makeMeFeelGood', {})
         self.assertRaises(AssertionError,
@@ -1305,22 +1303,6 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
         self.assertEqual(inc_point_source.mfd.bin_width, 0.1)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[0], 0.05)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[1], 0.01)
-
-#
-#
-#
-#        
-#
-#    def test_ignore_non_gr_mfd(self):
-#        uncertainties = [('maxMagGRAbsolute', 10),
-#                         ('abGRAbsolute', (-1, 0.3))]
-#        source = self.point_source
-#        source.mfd = EvenlyDiscretizedMFD(min_mag=3, bin_width=1,
-#                                          occurrence_rates=[1, 2, 3])
-#        source.mfd.modify = lambda *args, **kwargs: self.fail()
-#        for uncertainty, value in uncertainties:
-#            branchset = logictree.BranchSet(uncertainty, {})
-#            branchset.apply_uncertainty(value, source)
 
 
 class BranchSetFilterTestCase(unittest.TestCase):


### PR DESCRIPTION
Waaaay back in time, the "modify_set_mfd" option was added to the EvenlyDisctretizedMFD class in the oq-hazardlib (https://github.com/gem/oq-hazardlib/pull/262). This allows the user to define explicit incremental MFD values to a source (or sources) within a logic tree. This PR propagates this functionality to the oq-risklib, adding a new epistemic uncertainty type to the source model logic tree class: "incrementalMFDAbsolute".

The uncertainty model used to describe this takes the form of a string: 
`min_mag,bin_width,rate_1 rate_2 ... rate_2`
where the minimum magnitude, bin width and rates list are comma sparated, but the rates themselves are whitespace delimited.