### PR TITLE
Fixed the loss curves saving

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the EventBasedRisk demo to produce loss curves
   * Improved the memory consumption and data transfer of the event_based_risk
     calculator
   * The ProbabilisticEventBased risk demo works with a single job.ini

--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -43,7 +43,7 @@ loss_curve_resolution = 20
 conditional_loss_poes = 0.01
 insured_losses = True
 specific_assets = 
-loss_ratios = {'structural': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], 'nonstructural': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
+loss_ratios = {'structural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], 'nonstructural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
 
 [outputs]
 ground_motion_fields = false

--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -43,6 +43,7 @@ loss_curve_resolution = 20
 conditional_loss_poes = 0.01
 insured_losses = True
 specific_assets = 
+loss_ratios = {'structural': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], 'nonstructural': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
 
 [outputs]
 ground_motion_fields = false

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -277,6 +277,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         :param result:
             a numpy array of shape (O, L, R) containing lists of arrays
         """
+        insured_losses = self.oqparam.insured_losses
         ses_ratio = self.oqparam.ses_ratio
         saved = {out: 0 for out in self.outs}
         N = len(self.assetcol)
@@ -284,6 +285,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                           autoflush=True, measuremem=True):
             for (o, l, r), data in numpy.ndenumerate(result):
                 if not data:  # empty list
+                    continue
+                elif o == IC and not insured_losses:  # no insured curves
                     continue
                 cb = self.riskmodel.curve_builders[l]
                 if o in (AGGLOSS, SPECLOSS):  # data is a list of arrays
@@ -302,7 +305,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                 elif cb.user_provided:  # risk curves
                     # data is a list of dicts asset idx -> counts
                     poes = cb.build_poes(N, data, ses_ratio)
-                    self.datasets[o, l, r] = poes
+                    self.datasets[o, l, r].dset[:] = poes
                     saved[self.outs[o]] += poes.nbytes
                 self.datastore.hdf5.flush()
 

--- a/openquake/qa_tests_data/event_based_risk/case_1/job_risk.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job_risk.ini
@@ -24,4 +24,6 @@ conditional_loss_poes = 0.1, 0.5, 0.9
 
 quantile_loss_curves = 0.25
 
+loss_ratios = {'structural': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
+
 export_dir = /tmp/eb

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -126,14 +126,16 @@ class RiskModel(collections.Mapping):
         """
         Populate the inner lists .loss_types, .curve_builders.
         """
+        default_loss_ratios = numpy.linspace(
+            0, 1, oqparam.loss_curve_resolution + 1)[1:]
         for i, loss_type in enumerate(self.get_loss_types()):
-            if not oqparam.loss_ratios:
-                loss_ratios = numpy.linspace(
-                    0, 1, oqparam.loss_curve_resolution + 1)[1:]
-                cb = scientific.CurveBuilder(loss_type, loss_ratios, False)
-            else:  # user-provided loss ratios
-                loss_ratios = oqparam.loss_ratios[loss_type]
-                cb = scientific.CurveBuilder(loss_type, loss_ratios, True)
+            if loss_type in oqparam.loss_ratios:
+                cb = scientific.CurveBuilder(
+                    loss_type, oqparam.loss_ratios[loss_type],
+                    user_provided=True)
+            else:
+                cb = scientific.CurveBuilder(
+                    loss_type, default_loss_ratios, user_provided=False)
             self.curve_builders.append(cb)
             self.loss_types.append(loss_type)
             self.lti[loss_type] = i

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -950,7 +950,7 @@ class CurveBuilder(object):
         counts_matrix = self.get_counts(N, count_dicts)
         poes = build_poes(counts_matrix, 1. / ses_ratio)
         # poes has shape (N, R) and goes into a composite array of shape N
-        return poes.view(self.lr_dt)[:, 0]
+        return poes.view(self.lr_dt).reshape(N)
 
     def build_loss_curves(self, assetcol, losses_by_aid, ses_ratio):
         """

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -904,7 +904,7 @@ class CurveBuilder(object):
         self.ratios = numpy.array(loss_ratios, F32)
         self.user_provided = user_provided
         self.curve_resolution = len(loss_ratios)
-        R = self.curve_resolution or 1  # avoid bug in hdf5 2.0
+        R = self.curve_resolution
         self.loss_curve_dt = numpy.dtype([
             ('losses', (F32, R)), ('poes', (F32, R)), ('avg', F32)])
         self.lr_dt = numpy.dtype([('poes', (F32, R))])
@@ -949,7 +949,8 @@ class CurveBuilder(object):
         """
         counts_matrix = self.get_counts(N, count_dicts)
         poes = build_poes(counts_matrix, 1. / ses_ratio)
-        return poes.view(self.lr_dt)
+        # poes has shape (N, R) and goes into a composite array of shape N
+        return poes.view(self.lr_dt)[:, 0]
 
     def build_loss_curves(self, assetcol, losses_by_aid, ses_ratio):
         """
@@ -973,7 +974,7 @@ class CurveBuilder(object):
     def __repr__(self):
         return '<%s %s=%s user_provided=%s>' % (
             self.__class__.__name__, self.loss_type,
-            self.loss_ratios, self.user_provided)
+            self.ratios, self.user_provided)
 
 
 # should I use the ses_ratio here?


### PR DESCRIPTION
There was a type bug so that the curves were not stored correctly in the HDF5 file. I am extending the EventBasedRisk demo to produce the curves. A test will be added later on (see https://github.com/gem/oq-risklib/issues/484).
The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1155/console