### PR TITLE
RHEL packages demos

### DIFF
--- a/rpm/makerpm.sh
+++ b/rpm/makerpm.sh
@@ -38,9 +38,8 @@ while (( "$#" )); do
             shift
             ;;
         "-c")
-            rm -Rf $BASE/build-rpm
-            echo "$BASE/build-rpm cleaned"
-            exit 0
+            CLEAN=1
+            shift
             ;;
         *)
             BRANCH="$1"
@@ -48,6 +47,14 @@ while (( "$#" )); do
             ;;
     esac
 done
+
+if [ "$CLEAN" == "1" ]; then
+    rm -Rf $BASE/build-rpm
+    echo "$BASE/build-rpm cleaned"
+    if [ "$BUILD" != "1" ]; then
+        exit 0
+    fi
+fi
 
 cd $BASE
 mkdir -p build-rpm/{RPMS,SOURCES,SPECS,SRPMS}

--- a/rpm/makerpm.sh
+++ b/rpm/makerpm.sh
@@ -30,7 +30,7 @@ while (( "$#" )); do
     case "$1" in
         "-h")
             echo "Usage: $0 [-c] [-l] [BRANCH]"
-            echo -e "\nOptions:\n\t-l: build RPM locally\n\t-c: clean build dir"
+            echo -e "\nOptions:\n\t-l: build RPM locally\n\t-c: clean build dir before starting a new build"
             exit 0
             ;;
         "-l")
@@ -51,9 +51,6 @@ done
 if [ "$CLEAN" == "1" ]; then
     rm -Rf $BASE/build-rpm
     echo "$BASE/build-rpm cleaned"
-    if [ "$BUILD" != "1" ]; then
-        exit 0
-    fi
 fi
 
 cd $BASE

--- a/rpm/python-oq-risklib.spec.inc
+++ b/rpm/python-oq-risklib.spec.inc
@@ -64,13 +64,16 @@ python setup.py build
 
 %install
 python setup.py install --single-version-externally-managed -O1 --root=%{buildroot} --record=INSTALLED_FILES
+mkdir -p %{buildroot}/%{_datadir}/openquake/risklib
+cp -R demos %{buildroot}/%{_datadir}/openquake/risklib
 
 %clean
 rm -rf %{buildroot}
 
 %files -f INSTALLED_FILES
+%files %{buildroot}/%{_datadir}/openquake/risklib
 %defattr(-,root,root)
-%doc LICENSE README.md doc demos
+%doc LICENSE README.md doc
 
 %changelog
 * %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqtimestamp}_%{oqrelease}

--- a/rpm/python-oq-risklib.spec.inc
+++ b/rpm/python-oq-risklib.spec.inc
@@ -73,6 +73,7 @@ rm -rf %{buildroot}
 %files -f INSTALLED_FILES
 %defattr(-,root,root)
 %doc LICENSE README.md doc
+%dir %{_datadir}/openquake
 %{_datadir}/openquake/risklib
 
 %changelog

--- a/rpm/python-oq-risklib.spec.inc
+++ b/rpm/python-oq-risklib.spec.inc
@@ -71,9 +71,9 @@ cp -R demos %{buildroot}/%{_datadir}/openquake/risklib
 rm -rf %{buildroot}
 
 %files -f INSTALLED_FILES
-%files %{buildroot}/%{_datadir}/openquake/risklib
 %defattr(-,root,root)
 %doc LICENSE README.md doc
+%{_datadir}/openquake/risklib
 
 %changelog
 * %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqtimestamp}_%{oqrelease}


### PR DESCRIPTION
Update demos location per https://github.com/gem/oq-engine/issues/1893 (RedHat side).

Improves also the cleanup of `/usr/share/openquake` upon package removal.