### PR TITLE
Added a validation on the cost types

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Added a check on the cost types read from the exposure
+
   [Matteo Nastasi]
   * demos moved to /usr/share/openquake/risklib
   

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -200,7 +200,7 @@ class ExposureDataNode(LiteralNode):
     validators = dict(
         id=valid.simple_id,
         description=valid.utf8,
-        name=valid.name,
+        name=valid.cost_type,
         type=valid.name,
         insuranceLimit=float_or_flag,
         deductible=float_or_flag,

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -638,8 +638,10 @@ class DuplicatedID(Exception):
     Raised when two assets with the same ID are found in an exposure model
     """
 
-cost_type_dt = numpy.dtype([('name', '|S20'), ('type', '|S20'),
-                            ('unit', '|S20')])
+COST_TYPE_SIZE = 21  # using 21 chars since business_interruption has 21 chars
+cost_type_dt = numpy.dtype([('name', (bytes, COST_TYPE_SIZE)),
+                            ('type', (bytes, COST_TYPE_SIZE)),
+                            ('unit', (bytes, COST_TYPE_SIZE))])
 
 
 def get_exposure_lazy(fname, ok_cost_types):
@@ -670,12 +672,19 @@ def get_exposure_lazy(fname, ok_cost_types):
         area = conversions.area
     except NameError:
         area = LiteralNode('area', dict(type=''))
+
+    # read the cost types and make some check
     cost_types = [(ct['name'], ct['type'], ct['unit'])
                   for ct in conversions.costTypes
                   if ct['name'] in ok_cost_types]
     if 'occupants' in ok_cost_types:
         cost_types.append(('occupants', 'per_area', 'people'))
     cost_types.sort(key=operator.itemgetter(0))
+    for row in cost_types:
+        for col in row:
+            if len(col) > COST_TYPE_SIZE:
+                raise ValueError('The cost_type %s has a field too long, more '
+                                 'than %d chars' % (row, COST_TYPE_SIZE))
     return Exposure(
         exposure['id'], exposure['category'],
         ~description, numpy.array(cost_types, cost_type_dt),

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -632,16 +632,16 @@ def get_risk_model(oqparam):
 
 # ########################### exposure ############################ #
 
+COST_TYPE_SIZE = 21  # using 21 chars since business_interruption has 21 chars
+cost_type_dt = numpy.dtype([('name', (bytes, COST_TYPE_SIZE)),
+                            ('type', (bytes, COST_TYPE_SIZE)),
+                            ('unit', (bytes, COST_TYPE_SIZE))])
+
 
 class DuplicatedID(Exception):
     """
     Raised when two assets with the same ID are found in an exposure model
     """
-
-COST_TYPE_SIZE = 21  # using 21 chars since business_interruption has 21 chars
-cost_type_dt = numpy.dtype([('name', (bytes, COST_TYPE_SIZE)),
-                            ('type', (bytes, COST_TYPE_SIZE)),
-                            ('unit', (bytes, COST_TYPE_SIZE))])
 
 
 def get_exposure_lazy(fname, ok_cost_types):
@@ -680,12 +680,6 @@ def get_exposure_lazy(fname, ok_cost_types):
     if 'occupants' in ok_cost_types:
         cost_types.append(('occupants', 'per_area', 'people'))
     cost_types.sort(key=operator.itemgetter(0))
-    for row in cost_types:
-        valid.simple_id(row[0])  # the name
-        for col in row:
-            if len(col) > COST_TYPE_SIZE:
-                raise ValueError('The cost_type %s has a field too long, more '
-                                 'than %d chars' % (row, COST_TYPE_SIZE))
     return Exposure(
         exposure['id'], exposure['category'],
         ~description, numpy.array(cost_types, cost_type_dt),

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -34,7 +34,7 @@ from openquake.commonlib.datastore import DataStore
 from openquake.commonlib.oqvalidation import OqParam, rmdict
 from openquake.commonlib.node import read_nodes, LiteralNode, context
 from openquake.commonlib import nrml, valid, logictree, InvalidFile, parallel
-from openquake.commonlib.riskmodels import get_risk_files, get_risk_models
+from openquake.commonlib.riskmodels import get_risk_models
 from openquake.baselib.general import groupby, AccumDict, writetmp
 from openquake.baselib.performance import DummyMonitor
 from openquake.baselib.python3compat import configparser
@@ -681,6 +681,7 @@ def get_exposure_lazy(fname, ok_cost_types):
         cost_types.append(('occupants', 'per_area', 'people'))
     cost_types.sort(key=operator.itemgetter(0))
     for row in cost_types:
+        valid.simple_id(row[0])  # the name
         for col in row:
             if len(col) > COST_TYPE_SIZE:
                 raise ValueError('The cost_type %s has a field too long, more '

--- a/openquake/commonlib/riskmodels.py
+++ b/openquake/commonlib/riskmodels.py
@@ -33,9 +33,10 @@ from openquake.commonlib.sourcewriter import obj_to_node
 
 F64 = numpy.float64
 
+COST_TYPE_REGEX = '|'.join(valid.cost_type.choices)
+
 LOSS_TYPE_KEY = re.compile(
-    '(structural|nonstructural|contents|business_interruption|'
-    'occupants|fragility)_([\w_]+)')
+    '(%s|occupants|fragility)_([\w_]+)' % COST_TYPE_REGEX)
 
 
 def get_risk_files(inputs):
@@ -117,9 +118,7 @@ def get_risk_models(oqparam, kind):
     """
     rmodels = {}
     for key in oqparam.inputs:
-        mo = re.match(
-            '(occupants|structural|nonstructural|contents|'
-            'business_interruption)_%s$' % kind, key)
+        mo = re.match('(occupants|%s)_%s$' % (COST_TYPE_REGEX, kind), key)
         if mo:
             key_type = mo.group(1)  # the cost_type in the key
             # can be occupants, structural, nonstructural, ...

--- a/openquake/commonlib/valid.py
+++ b/openquake/commonlib/valid.py
@@ -791,6 +791,10 @@ def site_param(z1pt0, z2pt5, vs30Type, vs30, lon, lat, backarc="false"):
                      positivefloat(vs30), longitude(lon),
                      latitude(lat), boolean(backarc))
 
+# used for the exposure validation
+cost_type = Choice('structural', 'nonstructural', 'contents',
+                   'business_interruption')
+
 
 ###########################################################################
 


### PR DESCRIPTION
The business_interruption cost_type gave in error in Anirudh's tests (https://ci.openquake.org/job/zdevel_oq-risk-tests/73/console) since it is 21 characters long and the limit was set to 20, so it was silently truncated.