### PR TITLE
Printing the running time of the slowest tests

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -305,7 +305,8 @@ _devtest_innervm_run () {
 
         ssh $lxc_ip "export PYTHONPATH=\"\$PWD/oq-risklib:\$PWD/oq-hazardlib\" ;
                  cd $GEM_GIT_PACKAGE ;
-                 nosetests -a '${skip_tests}' -v --with-doctest --with-coverage --cover-package=openquake.baselib --cover-package=openquake.risklib --cover-package=openquake.commonlib --with-xunit"
+                 nosetests -a '${skip_tests}' -v --with-doctest --with-coverage --cover-package=openquake.baselib --cover-package=openquake.risklib --cover-package=openquake.commonlib --with-xunit ;
+                 bin/slowtests nosetests.xml"
         scp "$lxc_ip:$GEM_GIT_PACKAGE/nosetests.xml" "out_${BUILD_UBUVER}/"
     else
         if [ -d $HOME/fake-data/$GEM_GIT_PACKAGE ]; then


### PR DESCRIPTION
See https://ci.openquake.org/job/zdevel_oq-risklib/1239/console.
The 20 slowest tests are the following:

openquake.calculators.tests.event_based_risk_test.EventBasedRiskTestCase.test_case_3 98.822
openquake.calculators.tests.classical_risk_test.ClassicalRiskTestCase.test_case_3 59.152
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_5 41.079
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_18 30.729
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_7 26.392
openquake.calculators.tests.classical_test.ClassicalTestCase.test_case_3 25.837
openquake.calculators.tests.scenario_test.ScenarioHazardTestCase.test_case_7 24.448
openquake.calculators.tests.scenario_test.ScenarioHazardTestCase.test_case_5 23.934
openquake.calculators.tests.event_based_risk_test.EventBasedRiskTestCase.test_case_4 21.175
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_2bis 20.693
openquake.calculators.tests.event_based_risk_test.EventBasedRiskTestCase.test_case_4_hazard 20.571
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_blocksize 19.031
openquake.calculators.tests.classical_test.ClassicalTestCase.test_case_13 16.45
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_6 14.74
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_spatial_correlation 12.562
openquake.calculators.tests.event_based_test.EventBasedTestCase.test_case_2 11.828
openquake.calculators.tests.classical_tiling_test.ClassicalTestCase.test_case_1 7.745
openquake.commonlib.tests.source_test.NrmlSourceToHazardlibTestCase.test_characteristic_complex 7.421
openquake.calculators.tests.classical_test.ClassicalTestCase.test_case_21 6.717
openquake.calculators.tests.classical_test.ClassicalTestCase.test_case_11 6.323

In the future Jenkins could be configured as in the engine, when the xunit files are used directly.