### PR TITLE
Added a check on the uniform_hazard_spectra parameter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check on the uniform_hazard_specta parameter depending on the IMTs
   * Fixed a sorting error in the CSV exporters by asset
   * Fully ported the classical_risk calculator to oq-lite
   * Added a check for the case of no assets within the region

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added a check on the uniform_hazard_specta parameter depending on the IMTs
+  * Added a check on the uniform_hazard_spectra parameter depending on the IMTs
   * Fixed a sorting error in the CSV exporters by asset
   * Fully ported the classical_risk calculator to oq-lite
   * Added a check for the case of no assets within the region

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -391,3 +391,14 @@ class OqParam(valid.ParamSet):
         if rms and not getattr(self, 'complex_fault_mesh_spacing', None):
             self.complex_fault_mesh_spacing = self.rupture_mesh_spacing
         return True
+
+    def is_valid_uniform_hazard_spectra(self):
+        """
+        The `uniform_hazard_spectra` can be True only if the IMT set contains
+        SA(...) or PGA.
+        """
+        ok_imts = [imt for imt in self.imtls if imt == 'PGA' or
+                   imt.startswith('SA')]
+        if not self.uniform_hazard_spectra:
+            return True
+        return bool(ok_imts)

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -224,15 +224,18 @@ class OqParamTestCase(unittest.TestCase):
                       " required by the GSIM AbrahamsonSilva1997",
                       str(ctx.exception))
 
-    def _test_uniform_hazard_spectra(self):
+    def test_uniform_hazard_spectra(self):
         with self.assertRaises(ValueError) as ctx:
             OqParam(
                 calculation_mode='classical',
-                gsim='AbrahamsonSilva1997',
+                gsim='BooreAtkinson2008',
+                reference_vs30_value=200,
                 sites='0.1 0.2',
+                poes='0.2',
                 maximum_distance=400,
-                intensity_measure_types='PGV',
+                intensity_measure_types_and_levels="{'PGV': [0.1, 0.2, 0.3]}",
+                uniform_hazard_spectra='1',
             ).validate()
-        self.assertIn("Please set a value for 'reference_vs30_value', this is"
-                      " required by the GSIM AbrahamsonSilva1997",
+        self.assertIn("The `uniform_hazard_spectra` can be True only if "
+                      "the IMT set contains\nSA(...) or PGA",
                       str(ctx.exception))

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -223,3 +223,16 @@ class OqParamTestCase(unittest.TestCase):
         self.assertIn("Please set a value for 'reference_vs30_value', this is"
                       " required by the GSIM AbrahamsonSilva1997",
                       str(ctx.exception))
+
+    def _test_uniform_hazard_spectra(self):
+        with self.assertRaises(ValueError) as ctx:
+            OqParam(
+                calculation_mode='classical',
+                gsim='AbrahamsonSilva1997',
+                sites='0.1 0.2',
+                maximum_distance=400,
+                intensity_measure_types='PGV',
+            ).validate()
+        self.assertIn("Please set a value for 'reference_vs30_value', this is"
+                      " required by the GSIM AbrahamsonSilva1997",
+                      str(ctx.exception))


### PR DESCRIPTION
The problem was discovered by an user in Taiwan, trying to compute UHS curves for PGV. The error should happen at the beginning, not at the end of the computation.