### PR TITLE
Passed monitor and datastore to the SourceProcessor

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -70,7 +70,6 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     taxonomies = datastore.persistent_attribute('taxonomies')
     job_info = datastore.persistent_attribute('job_info')
     source_chunks = datastore.persistent_attribute('source_chunks')
-    source_pre_info = datastore.persistent_attribute('source_pre_info')
     performance = datastore.persistent_attribute('performance')
     csm = datastore.persistent_attribute('composite_source_model')
     pre_calculator = None  # to be overridden
@@ -378,7 +377,6 @@ class HazardCalculator(BaseCalculator):
                     self.oqparam, self.sitecol, self.SourceProcessor,
                     self.monitor)
                 # we could manage limits here
-                self.source_pre_info = self.csm.source_info
                 self.job_info = readinput.get_job_info(
                     self.oqparam, self.csm, self.sitecol)
                 self.csm.count_ruptures()

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -375,7 +375,7 @@ class HazardCalculator(BaseCalculator):
                     'reading composite source model', autoflush=True):
                 self.csm = readinput.get_composite_source_model(
                     self.oqparam, self.sitecol, self.SourceProcessor,
-                    self.monitor)
+                    self.monitor, dstore=self.datastore)
                 # we could manage limits here
                 self.job_info = readinput.get_job_info(
                     self.oqparam, self.csm, self.sitecol)

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -293,8 +293,8 @@ class Fake(dict):
     """
     A fake datastore as a dict subclass, useful in tests and such
     """
-    def __init__(self, attrs, **kwargs):
-        self.attrs = {k: repr(v) for k, v in attrs.items()}
+    def __init__(self, attrs=None, **kwargs):
+        self.attrs = {k: repr(v) for k, v in attrs.items()} if attrs else {}
         self.update(kwargs)
 
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -822,21 +822,22 @@ class SourceFilter(BaseSourceProcessor):
             sources_by_trt = self.agg_source_info(
                 sources_by_trt, self.filter(src))
         seqtime = time.time() - t1
-        self.update(csm, sources_by_trt)
+        self.update(csm, dstore, sources_by_trt)
         logging.info('fast sources filtering/splitting: %s', seqtime)
         logging.info('slow sources filtering/splitting: %s', partime)
 
-    def update(self, csm, sources_by_trt):
+    def update(self, csm, dstore, sources_by_trt):
         """
         Store the `source_info` array in the composite source model.
 
         :param csm: a CompositeSourceModel instance
+        :param dstore: a DataStore instance
         :param sources_by_trt: a dictionary trt_model_id -> sources
         """
         self.infos.sort(
             key=lambda info: info.filter_time + info.weight_time +
             info.split_time, reverse=True)
-        csm.source_info = numpy.array(self.infos, source_info_dt)
+        dstore['pre_source_info'] = numpy.array(self.infos, source_info_dt)
         del self.infos[:]
 
         # update trt_model.sources
@@ -913,6 +914,6 @@ class SourceFilterSplitter(SourceFilterWeighter):
         if slow_sources:
             partime = time.time() - t0
 
-        self.update(csm, sources_by_trt)
+        self.update(csm, dstore, sources_by_trt)
 
         return seqtime, partime


### PR DESCRIPTION
This is a minor refactoring. The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1244