### PR TITLE
Improved an error message

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -118,7 +118,7 @@ class ClassicalCalculator(base.HazardCalculator):
         parallelizing on the sources according to their weight and
         tectonic region type.
         """
-        monitor = self.monitor(self.core_func.__name__)
+        monitor = self.monitor.new(self.core_func.__name__)
         monitor.oqparam = self.oqparam
         sources = self.csm.get_sources()
         zc = zero_curves(len(self.sitecol.complete), self.oqparam.imtls)
@@ -132,7 +132,7 @@ class ClassicalCalculator(base.HazardCalculator):
             concurrent_tasks=self.oqparam.concurrent_tasks,
             weight=operator.attrgetter('weight'),
             key=operator.attrgetter('trt_model_id'))
-        monitor.flush()  # this is needed for the sequential case
+        monitor.flush()
         if self.persistent:
             store_source_chunks(self.datastore)
         return curves_by_trt_gsim

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -315,7 +315,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         return apply_reduce(
             self.core_func.__func__,
             (self.riskinputs, self.riskmodel, self.rlzs_assoc,
-             self.assets_by_site, self.monitor),
+             self.assets_by_site, self.monitor.new('task')),
             concurrent_tasks=self.oqparam.concurrent_tasks, agg=self.agg,
             weight=operator.attrgetter('weight'),
             key=operator.attrgetter('col_id'))
@@ -458,7 +458,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
             self.datastore['agg_loss_table'].values())]
         ses_ratio = self.oqparam.ses_ratio
         result = parallel.apply_reduce(
-            build_agg_curve, (r_data, self.I, ses_ratio, C, self.monitor),
+            build_agg_curve, (r_data, self.I, ses_ratio, C, self.monitor('')),
             concurrent_tasks=self.oqparam.concurrent_tasks)
         agg_curve = numpy.zeros(self.R, loss_curve_dt)
         for l, r, name in result:

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -409,10 +409,15 @@ def do_not_aggregate(acc, value):
     return acc
 
 
-def noflush():
-    # this is set by the litetask decorator
-    raise RuntimeError('PerformanceMonitor.flush() must not be called '
-                       'by a worker!')
+class NoFlush(object):
+    # this is instantiated by the litetask decorator
+    def __init__(self, monitor, taskname):
+        self.monitor = monitor
+        self.taskname = taskname
+
+    def __call__(self):
+        raise RuntimeError('PerformanceMonitor(%r).flush() must not be called '
+                           'by %s!' % (self.monitor.operation, self.taskname))
 
 
 def litetask(func):
@@ -422,10 +427,11 @@ def litetask(func):
     """
     def wrapper(*args):
         monitor = args[-1]
-        monitor.flush = noflush
-        with monitor('total ' + func.__name__, measuremem=True):
+        monitor.flush = NoFlush(monitor, func.__name__)
+        with monitor('total ' + func.__name__, measuremem=True) as mon:
             result = func(*args)
         delattr(monitor, 'flush')
+        delattr(mon, 'flush')
         return result
     # NB: we need pickle=True because celery is using the worst possible
     # protocol; once we remove celery we can try to remove pickle=True

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -426,7 +426,7 @@ def rec_delattr(mon, name):
     """
     for child in mon.children:
         rec_delattr(child, name)
-    if hasattr(mon, name):
+    if name in vars(mon):
         delattr(mon, name)
 
 

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -426,7 +426,8 @@ def rec_delattr(mon, name):
     """
     for child in mon.children:
         rec_delattr(child, name)
-    delattr(mon, name)
+    if hasattr(mon, name):
+        delattr(mon, name)
 
 
 def litetask(func):

--- a/openquake/commonlib/tests/parallel_test.py
+++ b/openquake/commonlib/tests/parallel_test.py
@@ -56,6 +56,7 @@ class TaskManagerTestCase(unittest.TestCase):
         res = get_len(*pik_args).unpickle()
 
         # flushing error
-        self.assertIn('PerformanceMonitor.flush() must not be called', res[0])
+        self.assertIn('PerformanceMonitor(\'test\').flush() must not be called'
+                      ' by get_len!', res[0])
         self.assertEqual(res[1], RuntimeError)
         self.assertEqual(res[2].operation, mon.operation)


### PR DESCRIPTION
Now if a task tries to call `monitor.flush()` in the error message we get the name of the task and the name of the monitor. The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1248/

NB: this requires https://github.com/gem/oq-hazardlib/pull/401