### PR TITLE
Renamed --profile --> --slowest

### DIFF
--- a/openquake/commonlib/commands/__main__.py
+++ b/openquake/commonlib/commands/__main__.py
@@ -28,9 +28,8 @@ def oq_lite():
                 for mod in os.listdir(commands.__path__[0])
                 if mod.endswith('.py') and not mod.startswith('_')]
     parsers = [importlib.import_module(modname).parser for modname in modnames]
-    parser = sap.compose(parsers)
+    parser = sap.compose(parsers, prog='oq-lite')
     parser.parentparser.version = __version__
-    parser.parentparser.prog = 'oq-lite'
     parser.callfunc()
 
 if __name__ == '__main__':

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -1,7 +1,7 @@
 #  -*- coding: utf-8 -*-
 #  vim: tabstop=4 shiftwidth=4 softtabstop=4
 
-#  Copyright (c) 2014, GEM Foundation
+#  Copyright (c) 2014-2015, GEM Foundation
 
 #  OpenQuake is free software: you can redistribute it and/or modify it
 #  under the terms of the GNU Affero General Public License as published
@@ -114,7 +114,7 @@ def _run(job_ini, concurrent_tasks, pdb, loglevel, hc, exports):
     return calc
 
 
-def run(job_ini, slowest, concurrent_tasks, hc, exports,
+def run(job_ini, slowest, concurrent_tasks, hc, exports='',
         loglevel='info', pdb=None):
     """
     Run a calculation.

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -148,7 +148,7 @@ def run(job_ini, slowest, concurrent_tasks, hc, exports='',
 parser = sap.Parser(run)
 parser.arg('job_ini', 'calculation configuration file '
            '(or files, comma-separated)')
-parser.opt('slowest', 'enable profiling', type=int)
+parser.opt('slowest', 'profile and show the slowest operations', type=int)
 parser.opt('concurrent_tasks', 'hint for the number of tasks to spawn',
            type=int)
 parser.opt('hc', 'previous calculation ID', type=int)

--- a/openquake/commonlib/commands/run.py
+++ b/openquake/commonlib/commands/run.py
@@ -23,8 +23,10 @@ import pstats
 import io
 
 from openquake.baselib import performance, general
-from openquake.commonlib import sap, readinput, valid, datastore
+from openquake.commonlib import sap, readinput, valid, datastore, oqvalidation
 from openquake.calculators import base, views
+
+CT = oqvalidation.OqParam.concurrent_tasks.default
 
 calc_path = None  # set only when the flag --slowest is given
 
@@ -114,7 +116,7 @@ def _run(job_ini, concurrent_tasks, pdb, loglevel, hc, exports):
     return calc
 
 
-def run(job_ini, slowest, concurrent_tasks, hc, exports='',
+def run(job_ini, slowest, hc, concurrent_tasks=CT, exports='',
         loglevel='info', pdb=None):
     """
     Run a calculation.
@@ -123,10 +125,10 @@ def run(job_ini, slowest, concurrent_tasks, hc, exports='',
         the configuration file (or filew, comma-separated)
     :param slowest:
         enable Python cProfile functionality
-    :param concurrent_tasks:
-        the number of concurrent tasks (0 to disable the parallelization)
     :param hc:
         ID of the previous calculation (or None)
+    :param concurrent_tasks:
+        the number of concurrent tasks (0 to disable the parallelization)
     :param loglevel:
         the logging level (default 'info')
     :param exports:
@@ -149,9 +151,9 @@ parser = sap.Parser(run)
 parser.arg('job_ini', 'calculation configuration file '
            '(or files, comma-separated)')
 parser.opt('slowest', 'profile and show the slowest operations', type=int)
+parser.opt('hc', 'previous calculation ID', type=int)
 parser.opt('concurrent_tasks', 'hint for the number of tasks to spawn',
            type=int)
-parser.opt('hc', 'previous calculation ID', type=int)
 parser.opt('exports', 'export formats as a comma-separated string',
            type=valid.export_formats)
 parser.opt('loglevel', 'logging level',

--- a/openquake/commonlib/sap.py
+++ b/openquake/commonlib/sap.py
@@ -173,7 +173,7 @@ class Parser(object):
         return self.parentparser.format_help()
 
 
-def compose(parsers, name='main', description=None, help=True):
+def compose(parsers, name='main', description=None, help=True, prog=None):
     """
     Collects together different arguments parsers and builds a single
     Parser dispatching on the subparsers depending on
@@ -181,12 +181,15 @@ def compose(parsers, name='main', description=None, help=True):
 
     :param parsers: a list of Parser instances
     :param name: the name of the composed parser
+    :param description: description of the composed parser
+    :param help: help flag
+    :param prog: name of the script printed in the usage message
     """
     assert len(parsers) >= 1, parsers
     parentparser = argparse.ArgumentParser(
         description=description, add_help=help)
     subparsers = parentparser.add_subparsers(
-        help='available subcommands (see sub help)')
+        help='available subcommands (see sub help)', prog=prog)
     for p in parsers:
         subp = subparsers.add_parser(p.name)
         for args, kw in p.all_arguments:

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -87,7 +87,7 @@ class RunShowExportTestCase(unittest.TestCase):
         """
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         with Print.patch() as cls.p:
-            cls.datastore = _run(job_ini).datastore
+            cls.datastore = _run(job_ini, 0, False, 'info', None, '').datastore
 
     def test_run_calc(self):
         self.assertIn('See the output with hdfview', str(self.p))


### PR DESCRIPTION
This looks more readable. Also the help for the `run` command reads better:

```bash
$ oq-lite run -h
usage: oq-lite run [-h] [-s SLOWEST] [--hc HC] [-c 32] [-e] [-l info] [-d] job_ini

positional arguments:
  job_ini               calculation configuration file (or files, comma-
                        separated)

optional arguments:
  -h, --help            show this help message and exit
  -s SLOWEST, --slowest SLOWEST
                        profile and show the slowest operations
  --hc HC               previous calculation ID
  -c 32, --concurrent-tasks 32
                        hint for the number of tasks to spawn
  -e , --exports        export formats as a comma-separated string
  -l info, --loglevel info
                        logging level
  -d, --pdb             enable post mortem debugging
```