### PR TITLE
Fixed minor bug with steps_per_interval=1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed a small bug in classical_damage for steps_per_interval = 1
+
 python-oq-risklib (0.10.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -95,7 +95,7 @@ class OqParam(valid.ParamSet):
     loss_curve_resolution = valid.Param(valid.positiveint, 50)
     loss_ratios = valid.Param(valid.loss_ratios, ())
     lrem_steps_per_interval = valid.Param(valid.positiveint, 0)
-    steps_per_interval = valid.Param(valid.positiveint, 0)
+    steps_per_interval = valid.Param(valid.positiveint, 1)
     master_seed = valid.Param(valid.positiveint, 0)
     maximum_distance = valid.Param(valid.positivefloat)  # km
     asset_hazard_distance = valid.Param(valid.positivefloat, 5)  # km

--- a/openquake/qa_tests_data/classical_damage/case_1a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_1a/job_risk.ini
@@ -15,3 +15,4 @@ fragility_file = fragility_model.xml
 [calculation]
 # years
 investigation_time = 1
+steps_per_interval = 1

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1155,7 +1155,7 @@ def classical_damage(
         an array of M probabilities of occurrence where M is the numbers
         of damage states.
     """
-    if fragility_functions.steps_per_interval:  # interpolate
+    if fragility_functions.steps_per_interval > 1:  # interpolate
         imls = numpy.array(fragility_functions.interp_imls)
         min_val, max_val = hazard_imls[0], hazard_imls[-1]
         numpy.putmask(imls, imls < min_val, min_val)


### PR DESCRIPTION
An `if` was wrong, as discovered by Anirudh, so there was an
`AttributeError: 'FragilityFunctionList' object has no attribute 'interp_imls'` for `steps_per_interval=1`.