### PR TITLE
Added IMT information in export_hcurves_xml_json

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added IMT information in the hazard curve XML exporter
   * Fixed a small bug in classical_damage for steps_per_interval = 1
 
 python-oq-risklib (0.10.0-0~precise01) precise; urgency=low

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -117,7 +117,7 @@ class EventBasedTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_1(self):
-        out = self.run_calc(case_1.__file__, 'job.ini', exports='csv')
+        out = self.run_calc(case_1.__file__, 'job.ini', exports='csv,xml')
 
         [fname] = out['gmfs', 'csv']
         self.assertEqualFiles(
@@ -126,6 +126,10 @@ class EventBasedTestCase(CalculatorTestCase):
         [fname] = out['hcurves', 'csv']
         self.assertEqualFiles(
             'expected/hazard_curve-smltp_b1-gsimltp_b1.csv', fname)
+
+        [fname] = out['hcurves', 'xml']
+        self.assertEqualFiles(
+            'expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml', fname)
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_2(self):

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -423,11 +423,13 @@ def export_hcurves_xml_json(ekey, dstore):
         name = hazard_curve_name(
             dstore, ekey, kind, rlzs_assoc, oq.number_of_logic_tree_samples)
         for imt in oq.imtls:
+            imtype, sa_period, sa_damping = from_string(imt)
             fname = name[:-len_ext] + '-' + imt + '.' + export_type
             data = [HazardCurve(Location(site), poes[imt])
                     for site, poes in zip(sitemesh, curves)]
             writer = writercls(fname, investigation_time=oq.investigation_time,
-                               imls=oq.imtls[imt],
+                               imls=oq.imtls[imt], imt=imtype,
+                               sa_period=sa_period, sa_damping=sa_damping,
                                smlt_path='_'.join(rlz.sm_lt_path),
                                gsimlt_path=rlz.gsim_rlz.uid)
             writer.serialize(data)

--- a/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml
+++ b/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <hazardCurves
+    IMT="PGA"
+    gsimTreePath="b1"
+    investigationTime="1.0"
+    sourceModelTreePath="b1"
+    >
+        <IMLs>
+            1.000000000E-01 4.000000000E-01 6.000000000E-01
+        </IMLs>
+        <hazardCurve>
+            <gml:Point>
+                <gml:pos>
+                    0.0 0.0
+                </gml:pos>
+            </gml:Point>
+            <poEs>
+                4.596293576E-01 5.729323084E-02 1.192828714E-02
+            </poEs>
+        </hazardCurve>
+    </hazardCurves>
+</nrml>


### PR DESCRIPTION
As requested by Catalina, since this information is needed by the RMTK to plot the hazard curves.