### PR TITLE
Export empty files too

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Keep exporting files, even if they are empty
   * Exported information about the realizations into a csv file
   * Ported the disaggregation calculator to oq-lite
   * Added IMT information in the hazard curve XML exporter

--- a/openquake/commonlib/commands/show.py
+++ b/openquake/commonlib/commands/show.py
@@ -64,8 +64,8 @@ def show(calc_id, key=None, rlzs=None):
             return
         rows = []
         for calc_id in datastore.get_calc_ids(datastore.DATADIR):
-            ds = datastore.DataStore(calc_id, mode='r')
             try:
+                ds = datastore.DataStore(calc_id, mode='r')
                 oq = OqParam.from_(ds.attrs)
                 cmode, descr = oq.calculation_mode, oq.description
             except:
@@ -74,9 +74,9 @@ def show(calc_id, key=None, rlzs=None):
                 logging.warn('Removed invalid calculation %d', calc_id)
                 os.remove(
                     os.path.join(datastore.DATADIR, 'calc_%s.hdf5' % calc_id))
+                continue
             else:
                 rows.append((calc_id, cmode, descr))
-            finally:
                 ds.close()
         for row in sorted(rows, key=lambda row: row[0]):  # by calc_id
             print('#%d %s: %s' % row)

--- a/openquake/commonlib/writers.py
+++ b/openquake/commonlib/writers.py
@@ -267,8 +267,7 @@ def write_csv(dest, data, sep=',', fmt='%12.8E', header=None):
        optional list with the names of the columns to display
     """
     if len(data) == 0:
-        logging.warn('Not generating %s, it would be empty', dest)
-        return dest
+        logging.warn('%s is empty', dest)
     if not hasattr(dest, 'getvalue'):
         # not a StringIO, assume dest is a filename
         dest = open(dest, 'w')


### PR DESCRIPTION
Before empty files were not exported: this cause an issue with the engine, which was trying to zip non-exiting files.

PS: while working at it, I discovered and fixed a small bug with invalid .hdf5 files affecting the show command.