### PR TITLE
Worked around a bug in h5py.Group.visitems in Ubuntu 12.04

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Worked around a bug in h5File.visitems in Ubuntu 12.04
   * Reduced the precision of the site mesh to 32 bits
   * The source model logic tree parser supports NRML 0.5
   * Reduced the precision of the scenario_damage outputs to 32 bits

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -189,14 +189,25 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         then close the datastore.
         """
         if 'hcurves' in self.datastore:
-            self.datastore.set_nbytes('hcurves')
+            _set_nbytes('hcurves', self.datastore)
         if 'hmaps' in self.datastore:
-            self.datastore.set_nbytes('hmaps')
+            _set_nbytes('hmaps', self.datastore)
         if 'rlzs_assoc' in self.datastore:
             rlzs = self.rlzs_assoc.realizations
             self.realizations = numpy.array(
                 [(r.uid, r.weight) for r in rlzs], rlz_dt)
         # NB: the datastore must not be closed, it will be closed automatically
+
+
+def _set_nbytes(dkey, dstore):
+    # set the number of bytes assuming the dkey correspond to a flat group
+    # with all elements having the same 'nbytes' attribute
+    # NB: this is a workaround for a bug in HDF5 affecting Ubuntu 12.04;
+    # in newer version just use dstore.set_nbytes
+    # the problem was discovered in demos/hazard/LogicTreeCase1ClassicalPSHA
+    group = dstore[dkey]
+    key = group.keys()[0]
+    group.attrs['nbytes'] = group[key].attrs['nbytes'] * len(group)
 
 
 class HazardCalculator(BaseCalculator):

--- a/packager.sh
+++ b/packager.sh
@@ -505,6 +505,9 @@ _pkgtest_innervm_run () {
         echo 'running Disaggregation'
         oq-lite run Disaggregation/job.ini
 
+        echo 'running LogicTreeCase1ClassicalPSHA'
+        oq-lite run LogicTreeCase1ClassicalPSHA/job.ini
+
         echo 'running LogicTreeCase3ClassicalPSHA'
         oq-lite run LogicTreeCase3ClassicalPSHA/job.ini --exports xml
         oq-lite show -1 --rlzs


### PR DESCRIPTION
For some reason, we had a segmentation fault in the demo LogicTreeCase1ClassicalPSHA when using oq-lite on Ubuntu 12.04. The problem did not appear in other demos. The workaround is to not call DataStore.set_nbytes which in turn was calling the offending `visitems`.

The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1291