### PR TITLE
packager.sh: make CI job fails when tests are broken

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -303,9 +303,15 @@ _devtest_innervm_run () {
             skip_tests="!slow,"
         fi
 
-        ssh $lxc_ip "export PYTHONPATH=\"\$PWD/oq-risklib:\$PWD/oq-hazardlib\" ;
-                 cd $GEM_GIT_PACKAGE ;
-                 nosetests -a '${skip_tests}' -v --with-doctest --with-coverage --cover-package=openquake.baselib --cover-package=openquake.risklib --cover-package=openquake.commonlib --with-xunit ;
+        ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
+                 set -e
+                 if [ -n \"\$GEM_SET_DEBUG\" -a \"\$GEM_SET_DEBUG\" != \"false\" ]; then
+                     export PS4='+\${BASH_SOURCE}:\${LINENO}:\${FUNCNAME[0]}: '
+                     set -x
+                 fi
+                 export PYTHONPATH=\"\$PWD/oq-risklib:\$PWD/oq-hazardlib\"
+                 cd $GEM_GIT_PACKAGE
+                 nosetests -a '${skip_tests}' -v --with-doctest --with-coverage --cover-package=openquake.baselib --cover-package=openquake.risklib --cover-package=openquake.commonlib --with-xunit
                  bin/slowtests nosetests.xml"
         scp "$lxc_ip:$GEM_GIT_PACKAGE/nosetests.xml" "out_${BUILD_UBUVER}/"
     else


### PR DESCRIPTION
This makes the Jenkins job to exit (with a failure) when a test is broken. It also add support for the `GEM_DEBUG` functionality.

Tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1308/