### PR TITLE
Remove `specific_assets` from event based risk demo

### DIFF
--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -41,8 +41,7 @@ master_seed = 42
 asset_hazard_distance = 20
 loss_curve_resolution = 20
 conditional_loss_poes = 0.01 0.02
-insured_losses = True
-specific_assets = 
+insured_losses = true
 loss_ratios = {'structural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], 'nonstructural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
 
 [outputs]


### PR DESCRIPTION
This parameter was removed in https://github.com/gem/oq-risklib/pull/513