### PR TITLE
Removed duplication in the usage of psutil

### DIFF
--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -27,34 +27,12 @@ import operator
 import traceback
 from concurrent.futures import as_completed, ProcessPoolExecutor
 from decorator import FunctionMaker
-import psutil
 
 from openquake.baselib.python3compat import pickle
-from openquake.baselib.performance import PerformanceMonitor, DummyMonitor
+from openquake.baselib.performance import (
+    PerformanceMonitor, DummyMonitor, virtual_memory)
 from openquake.baselib.general import split_in_blocks, AccumDict, humansize
 from openquake.hazardlib.gsim.base import GroundShakingIntensityModel
-
-
-if psutil.__version__ > '2.0.0':  # Ubuntu 14.10
-    def virtual_memory():
-        return psutil.virtual_memory()
-
-    def memory_info(proc):
-        return proc.memory_info()
-
-elif psutil.__version__ >= '1.2.1':  # Ubuntu 14.04
-    def virtual_memory():
-        return psutil.virtual_memory()
-
-    def memory_info(proc):
-        return proc.get_memory_info()
-
-else:  # Ubuntu 12.04
-    def virtual_memory():
-        return psutil.phymem_usage()
-
-    def memory_info(proc):
-        return proc.get_memory_info()
 
 
 executor = ProcessPoolExecutor()

--- a/openquake/commonlib/tests/writers_test.py
+++ b/openquake/commonlib/tests/writers_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import tempfile
 from io import BytesIO
+from openquake.baselib.performance import memory_info
 from openquake.commonlib.writers import tostring, StreamingXMLWriter, write_csv
 from openquake.commonlib.node import LiteralNode
 from xml.etree import ElementTree as etree
@@ -58,7 +59,7 @@ xmlns="http://openquake.org/xmlns/nrml/0.4"
             raise unittest.SkipTest('psutil not installed')
         proc = psutil.Process(os.getpid())
         try:
-            rss = proc.get_memory_info().rss
+            rss = memory_info(proc).rss
         except psutil.AccessDenied:
             raise unittest.SkipTest('Memory info not accessible')
         devnull = open(os.devnull, 'w')


### PR DESCRIPTION
Let's use the wrapper functions in baselib to work with all versions of psutil.