### PR TITLE
Updated the datastore to manage serializable objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Introduced a serialization protocol to save objects in the datastore
+
   [Matteo Nastasi]
   * Add framework to run bash scripts tests and collect associated xunit report
   * Add concurrent_futures_process_monkeypatch() using python-prctl library


### PR DESCRIPTION
Implemented the scaffolding needed for the serialization protocol described in https://github.com/gem/oq-risklib/issues/652. As a beginning, I am serializing the site collection (https://github.com/gem/oq-hazardlib/pull/421).

The tests and demos are green: https://ci.openquake.org/job/zdevel_oq-risklib/1328