### PR TITLE
Stored the SESCollection as a set of pickled objects instead of a single one

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -446,8 +446,8 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
         logging.info('Saving the SES collection')
         with self.monitor('saving ruptures', autoflush=True):
             self.tags = numpy.array(tags, (bytes, 100))
-            for sc, seskey in zip(sescollection, cols):
-                self.datastore['sescollection/%s-%s' % tuple(seskey)] = sc
+            for sescol, seskey in zip(sescollection, cols):
+                self.datastore['sescollection/%s-%s' % tuple(seskey)] = sescol
         with self.monitor('counts_per_rlz'):
             self.num_ruptures = numpy.array(list(map(len, sescollection)))
             self.counts_per_rlz = counts_per_rlz(
@@ -582,9 +582,8 @@ class EventBasedCalculator(ClassicalCalculator):
         self.sesruptures = []
         gsims_by_col = self.rlzs_assoc.get_gsims_by_col()
         self.datasets = {}
-        for col_id, seskey in enumerate(
-                self.datastore['sescollection'].keys()):
-            sescol = self.datastore['sescollection/' + seskey]
+        for col_id, col in enumerate(self.rlzs_assoc.csm_info.cols):
+            sescol = self.datastore['sescollection/%s-%s' % tuple(col)]
             gmf_dt = gsim_imt_dt(gsims_by_col[col_id], self.oqparam.imtls)
             for tag, sesrup in sorted(sescol.items()):
                 sesrup = sescol[tag]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -446,8 +446,8 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
         logging.info('Saving the SES collection')
         with self.monitor('saving ruptures', autoflush=True):
             self.tags = numpy.array(tags, (bytes, 100))
-            for sescol, seskey in zip(sescollection, cols):
-                self.datastore['sescollection/%s-%s' % tuple(seskey)] = sescol
+            for sescol, colkey in zip(sescollection, cols):
+                self.datastore['sescollection/tecmod%s-%s' % tuple(colkey)] = sescol
         with self.monitor('counts_per_rlz'):
             self.num_ruptures = numpy.array(list(map(len, sescollection)))
             self.counts_per_rlz = counts_per_rlz(
@@ -583,7 +583,7 @@ class EventBasedCalculator(ClassicalCalculator):
         gsims_by_col = self.rlzs_assoc.get_gsims_by_col()
         self.datasets = {}
         for col_id, col in enumerate(self.rlzs_assoc.csm_info.cols):
-            sescol = self.datastore['sescollection/%s-%s' % tuple(col)]
+            sescol = self.datastore['sescollection/tecmod%s-%s' % tuple(col)]
             gmf_dt = gsim_imt_dt(gsims_by_col[col_id], self.oqparam.imtls)
             for tag, sesrup in sorted(sescol.items()):
                 sesrup = sescol[tag]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -446,8 +446,8 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
         logging.info('Saving the SES collection')
         with self.monitor('saving ruptures', autoflush=True):
             self.tags = numpy.array(tags, (bytes, 100))
-            for sescol, colkey in zip(sescollection, cols):
-                self.datastore['sescollection/tecmod%s-%s' % tuple(colkey)] = sescol
+            for col, colkey in zip(sescollection, cols):
+                self.datastore['sescollection/trtmod=%s-%s' % tuple(colkey)] = col
         with self.monitor('counts_per_rlz'):
             self.num_ruptures = numpy.array(list(map(len, sescollection)))
             self.counts_per_rlz = counts_per_rlz(
@@ -583,7 +583,7 @@ class EventBasedCalculator(ClassicalCalculator):
         gsims_by_col = self.rlzs_assoc.get_gsims_by_col()
         self.datasets = {}
         for col_id, col in enumerate(self.rlzs_assoc.csm_info.cols):
-            sescol = self.datastore['sescollection/tecmod%s-%s' % tuple(col)]
+            sescol = self.datastore['sescollection/trtmod=%s-%s' % tuple(col)]
             gmf_dt = gsim_imt_dt(gsims_by_col[col_id], self.oqparam.imtls)
             for tag, sesrup in sorted(sescol.items()):
                 sesrup = sescol[tag]

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -251,7 +251,9 @@ class EventBasedRiskCalculator(base.RiskCalculator):
             assets_by_site, oq.time_event)
 
         logging.info('Populating the risk inputs')
-        rup_by_tag = sum(self.datastore['sescollection'], AccumDict())
+        rup_by_tag = AccumDict()
+        for seskey in self.datastore['sescollection']:
+            rup_by_tag += self.datastore['sescollection/' + seskey]
         all_ruptures = [rup_by_tag[tag] for tag in sorted(rup_by_tag)]
         for i, rup in enumerate(all_ruptures):
             rup.ordinal = i

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -252,8 +252,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
 
         logging.info('Populating the risk inputs')
         rup_by_tag = AccumDict()
-        for seskey in self.datastore['sescollection']:
-            rup_by_tag += self.datastore['sescollection/' + seskey]
+        for colkey in self.datastore['sescollection']:
+            rup_by_tag += self.datastore['sescollection/' + colkey]
         all_ruptures = [rup_by_tag[tag] for tag in sorted(rup_by_tag)]
         for i, rup in enumerate(all_ruptures):
             rup.ordinal = i

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -56,7 +56,6 @@ class ScenarioCalculator(base.HazardCalculator):
     """
     core_task = calc_gmfs
     tags = datastore.persistent_attribute('tags')
-    sescollection = datastore.persistent_attribute('sescollection')
     is_stochastic = True
 
     def pre_execute(self):
@@ -87,20 +86,22 @@ class ScenarioCalculator(base.HazardCalculator):
         rnd = random.Random(self.oqparam.random_seed)
         self.tag_seed_pairs = [(tag, rnd.randint(0, calc.MAX_INT))
                                for tag in self.tags]
-        self.sescollection = [{tag: Rupture(tag, seed, rupture)
-                               for tag, seed in self.tag_seed_pairs}]
+        self.datastore['sescollection/tecmod0-0'] = {
+            tag: Rupture(tag, seed, rupture)
+            for tag, seed in self.tag_seed_pairs}
 
     def execute(self):
         """
         Compute the GMFs in parallel and return a dictionary gmf_by_tag
         """
         with self.monitor('computing gmfs', autoflush=True):
-            args = (self.tag_seed_pairs, self.computer, self.monitor('calc_gmfs'))
+            args = (self.tag_seed_pairs, self.computer,
+                    self.monitor('calc_gmfs'))
             gmf_by_tag = parallel.apply_reduce(
                 self.core_task.__func__, args,
                 concurrent_tasks=self.oqparam.concurrent_tasks)
             return gmf_by_tag
-    
+
     def post_execute(self, gmf_by_tag):
         """
         :param gmf_by_tag: a dictionary tag -> gmf

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -86,7 +86,7 @@ class ScenarioCalculator(base.HazardCalculator):
         rnd = random.Random(self.oqparam.random_seed)
         self.tag_seed_pairs = [(tag, rnd.randint(0, calc.MAX_INT))
                                for tag in self.tags]
-        self.datastore['sescollection/tecmod0-0'] = {
+        self.datastore['sescollection/trtmod=0-0'] = {
             tag: Rupture(tag, seed, rupture)
             for tag, seed in self.tag_seed_pairs}
 

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -91,8 +91,8 @@ def export_ses_xml(ekey, dstore):
     fnames = []
     for sm in csm_info.source_models:
         for trt_model in sm.trt_models:
-            key = 'sescollection/%s-%s' % tuple(csm_info.cols[col_id])
-            sesruptures = list(dstore[key].values())
+            seskey = 'sescollection/%s-%s' % tuple(csm_info.cols[col_id])
+            sesruptures = dstore[seskey].values()
             col_id += 1
             ses_coll = SESCollection(
                 groupby(sesruptures, operator.attrgetter('ses_idx')),

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -91,7 +91,7 @@ def export_ses_xml(ekey, dstore):
     fnames = []
     for sm in csm_info.source_models:
         for trt_model in sm.trt_models:
-            colkey = 'sescollection/tecmod%s-%s' % tuple(csm_info.cols[col_id])
+            colkey = 'sescollection/trtmod=%s-%s' % tuple(csm_info.cols[col_id])
             sesruptures = dstore[colkey].values()
             col_id += 1
             ses_coll = SESCollection(

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -91,8 +91,8 @@ def export_ses_xml(ekey, dstore):
     fnames = []
     for sm in csm_info.source_models:
         for trt_model in sm.trt_models:
-            seskey = 'sescollection/%s-%s' % tuple(csm_info.cols[col_id])
-            sesruptures = dstore[seskey].values()
+            colkey = 'sescollection/tecmod%s-%s' % tuple(csm_info.cols[col_id])
+            sesruptures = dstore[colkey].values()
             col_id += 1
             ses_coll = SESCollection(
                 groupby(sesruptures, operator.attrgetter('ses_idx')),
@@ -550,8 +550,8 @@ def export_gmf(ekey, dstore):
     sitecol = dstore['sitecol']
     rlzs_assoc = dstore['rlzs_assoc']
     rupture_by_tag = AccumDict()
-    for seskey in dstore['sescollection']:
-        rupture_by_tag += dstore['sescollection/' + seskey]
+    for colkey in dstore['sescollection']:
+        rupture_by_tag += dstore['sescollection/' + colkey]
     all_tags = dstore['tags'].value
     oq = OqParam.from_(dstore.attrs)
     investigation_time = (None if oq.calculation_mode == 'scenario'

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -87,12 +87,12 @@ def export_ses_xml(ekey, dstore):
         csm_info = dstore['rlzs_assoc'].csm_info
     except AttributeError:  # for scenario calculators don't export
         return []
-    sescollection = dstore['sescollection']
     col_id = 0
     fnames = []
     for sm in csm_info.source_models:
         for trt_model in sm.trt_models:
-            sesruptures = list(sescollection[col_id].values())
+            key = 'sescollection/%s-%s' % tuple(csm_info.cols[col_id])
+            sesruptures = list(dstore[key].values())
             col_id += 1
             ses_coll = SESCollection(
                 groupby(sesruptures, operator.attrgetter('ses_idx')),
@@ -549,7 +549,9 @@ def export_gmf(ekey, dstore):
     """
     sitecol = dstore['sitecol']
     rlzs_assoc = dstore['rlzs_assoc']
-    rupture_by_tag = sum(dstore['sescollection'], AccumDict())
+    rupture_by_tag = AccumDict()
+    for seskey in dstore['sescollection']:
+        rupture_by_tag += dstore['sescollection/' + seskey]
     all_tags = dstore['tags'].value
     oq = OqParam.from_(dstore.attrs)
     investigation_time = (None if oq.calculation_mode == 'scenario'

--- a/openquake/risklib/tests/riskinput_test.py
+++ b/openquake/risklib/tests/riskinput_test.py
@@ -85,7 +85,7 @@ a4,3,1,50,500000,2.0,6.0
         dstore = get_datastore(rupcalc)
 
         # this is case with a single SES collection
-        ses_ruptures = list(dstore['sescollection'][0].values())
+        ses_ruptures = dstore['sescollection/trtmod=0-0'].values()
 
         gsims_by_trt_id = rupcalc.rlzs_assoc.gsims_by_trt_id
 


### PR DESCRIPTION
This should help to solve https://github.com/gem/oq-risklib/issues/639 temporarily. It is important for the California project, so that Graeme can generate one collection per branch. The sescollections (each sescollection is a dictionary {tag: SESRupture} are stored by collection key (`colkey`) which is a string of the form `trtmod=<trt_id>-<idx>` where `trt_id` is the tectonic model index and `idx` is always zero
in the case of full enumeration. If sampling is enabled then `idx` is the sampling ordinal of the model.
For instance, in the test case_17, which has 2 tectonic region models and `number_of_logic_tree_samples = 5`, the SESCollection has the following 5 components:

sescollection/trtmod=0-0
sescollection/trtmod=1-0
sescollection/trtmod=1-2
sescollection/trtmod=1-3
sescollection/trtmod=1-4
