### PR TITLE
Added a SourceModelParser with caching

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Michele Simionato]
+  * Optimized the source model parsing
   * Fixed the initial accumulator in the EventBasedRuptureCalculator
-  
+
   [Anirudh Rao]
   * Removed the extra ScenarioDamage demo
   * Removed unused parameters from the risk demo job files

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1455,9 +1455,6 @@ class GsimLogicTree(object):
             yield Realization(tuple(value), weight, tuple(lt_path),
                               i, tuple(lt_uid))
 
-    def __len__(self):
-        return sum(1 for rlz in self)
-
     def __str__(self):
         lines = ['%s,%s,%s,w=%s' % (b.bset['applyToTectonicRegionType'],
                                     b.id, b.uncertainty, b.weight)

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1455,6 +1455,9 @@ class GsimLogicTree(object):
             yield Realization(tuple(value), weight, tuple(lt_path),
                               i, tuple(lt_uid))
 
+    def __len__(self):
+        return sum(1 for rlz in self)
+
     def __str__(self):
         lines = ['%s,%s,%s,w=%s' % (b.bset['applyToTectonicRegionType'],
                                     b.id, b.uncertainty, b.weight)

--- a/openquake/commonlib/node.py
+++ b/openquake/commonlib/node.py
@@ -142,9 +142,10 @@ generator. Finally, nodes containing lazy nodes will not be pickleable.
 """
 from openquake.baselib.python3compat import configparser, with_metaclass
 
-import sys
-import pprint as pp
 import io
+import sys
+import copy
+import pprint as pp
 from contextlib import contextmanager
 from openquake.baselib.python3compat import raise_, exec_
 from openquake.commonlib.writers import StreamingXMLWriter
@@ -358,6 +359,15 @@ class Node(object):
 
     if sys.version > '3':
         __bool__ = __nonzero__
+
+    def __deepcopy__(self, memo):
+        new = object.__new__(self.__class__)
+        new.tag = self.tag
+        new.attrib = self.attrib.copy()
+        new.text = copy.copy(self.text)
+        new.nodes = [copy.deepcopy(n, memo) for n in self.nodes]
+        new.lineno = self.lineno
+        return new
 
     def __getstate__(self):
         return dict((slot, getattr(self, slot))

--- a/openquake/commonlib/node.py
+++ b/openquake/commonlib/node.py
@@ -263,6 +263,9 @@ class Node(object):
                 'A branch node cannot have a value, got %r' % self.text)
 
     def __getattr__(self, name):
+        if name.startswith('_'):
+            # do the magic only for public names
+            raise AttributeError(name)
         for node in self.nodes:
             if striptag(node.tag) == name:
                 return node

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -426,7 +426,9 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
     # consider only the effective realizations
     rlzs = logictree.get_effective_rlzs(source_model_lt)
     samples_by_lt_path = source_model_lt.samples_by_lt_path()
+    num_source_models = len(rlzs)
     for i, rlz in enumerate(rlzs):
+        logging.info('Reading source model %d/%d', i + 1, num_source_models)
         sm = rlz.value  # name of the source model
         smpath = rlz.lt_path
         num_samples = samples_by_lt_path[smpath]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -421,6 +421,7 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         oqparam.complex_fault_mesh_spacing,
         oqparam.width_of_mfd_bin,
         oqparam.area_source_discretization)
+    parser = source.SourceModelParser(converter)
 
     # consider only the effective realizations
     rlzs = logictree.get_effective_rlzs(source_model_lt)
@@ -436,8 +437,7 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         if in_memory:
             apply_unc = source_model_lt.make_apply_uncertainties(smpath)
             try:
-                trt_models = source.parse_source_model(
-                    fname, converter, apply_unc, set_weight=in_memory)
+                trt_models = parser.parse_trt_models(fname, apply_unc)
             except ValueError as e:
                 if str(e) in ('Surface does not conform with Aki & '
                               'Richards convention',
@@ -470,6 +470,11 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         weight = rlz.weight / num_samples
         yield source.SourceModel(
             sm, weight, smpath, trt_models, gsim_lt, i, num_samples, None)
+
+    # log if some source file is being used more than once
+    for fname, hits in parser.fname_hits.items():
+        if hits > 1:
+            logging.info('%s has been considered %d times', fname, hits)
 
 
 def get_composite_source_model(oqparam, in_memory=True):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -470,7 +470,7 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
             gsim_lt = logictree.DummyGsimLogicTree()
         weight = rlz.weight / num_samples
         logging.info('Read source model %d/%d with %d gsim realizations',
-                     i + 1, num_source_models, gsim_lt.get_num_paths())
+                     i + 1, num_source_models, len(gsim_lt))
         yield source.SourceModel(
             sm, weight, smpath, trt_models, gsim_lt, i, num_samples)
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -428,7 +428,6 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
     samples_by_lt_path = source_model_lt.samples_by_lt_path()
     num_source_models = len(rlzs)
     for i, rlz in enumerate(rlzs):
-        logging.info('Reading source model %d/%d', i + 1, num_source_models)
         sm = rlz.value  # name of the source model
         smpath = rlz.lt_path
         num_samples = samples_by_lt_path[smpath]
@@ -470,6 +469,8 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         else:
             gsim_lt = logictree.DummyGsimLogicTree()
         weight = rlz.weight / num_samples
+        logging.info('Read source model %d/%d with %d gsim realizations',
+                     i + 1, num_source_models, gsim_lt.get_num_paths())
         yield source.SourceModel(
             sm, weight, smpath, trt_models, gsim_lt, i, num_samples)
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -469,8 +469,9 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         else:
             gsim_lt = logictree.DummyGsimLogicTree()
         weight = rlz.weight / num_samples
-        logging.info('Read source model %d/%d with %d gsim realizations',
-                     i + 1, num_source_models, len(gsim_lt))
+        n = num_samples if num_samples else gsim_lt.get_num_paths()
+        logging.info('Read source model %d/%d with %d gsim realization(s)',
+                     i + 1, num_source_models, n)
         yield source.SourceModel(
             sm, weight, smpath, trt_models, gsim_lt, i, num_samples)
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -214,9 +214,8 @@ class SourceModelParser(object):
             sources = self.sources[fname]
         except KeyError:
             sources = self.sources[fname] = self.parse_sources(fname)
-        # NB: deepcopy causes an error
-        # No subnode named '__deepcopy__' found in 'surface'
-        sources = map(copy.copy, sources)
+        # NB: deepcopy is *essential* here
+        sources = map(copy.deepcopy, sources)
         for src in sources:
             if apply_uncertainties:
                 apply_uncertainties(src)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -214,7 +214,9 @@ class SourceModelParser(object):
             sources = self.sources[fname]
         except KeyError:
             sources = self.sources[fname] = self.parse_sources(fname)
-        sources = map(copy.deepcopy, sources)
+        # NB: deepcopy causes an error
+        # No subnode named '__deepcopy__' found in 'surface'
+        sources = map(copy.copy, sources)
         for src in sources:
             if apply_uncertainties:
                 apply_uncertainties(src)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -749,7 +749,6 @@ class CompositeSourceModel(collections.Sequence):
         self.source_info = ()  # set by the SourceFilterSplitter
         self.split_map = {}
         if set_weight:
-            logging.info('')
             self.set_weights()
         # must go after set_weights to have the correct .num_ruptures
         self.info = CompositionInfo(

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -20,8 +20,6 @@ import operator
 
 from openquake.baselib.general import block_splitter
 from openquake.baselib.performance import PerformanceMonitor
-from openquake.hazardlib.source.point import PointSource
-from openquake.hazardlib.source.area import AreaSource
 from openquake.hazardlib import geo, mfd, pmf, source
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.commonlib.node import context, striptag
@@ -80,7 +78,7 @@ def area_to_point_sources(area_src):
         new_occur_rates = [float(x) / num_points
                            for x in area_mfd.occurrence_rates]
         new_mfd = mfd.ArbitraryMFD(
-            magnitudes=area.magnitudes,
+            magnitudes=area_mfd.magnitudes,
             occurrence_rates=new_occur_rates)
 
     for i, (lon, lat) in enumerate(zip(mesh.lons, mesh.lats)):

--- a/openquake/commonlib/tests/node_test.py
+++ b/openquake/commonlib/tests/node_test.py
@@ -14,6 +14,7 @@
 # along with NRML.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
+import copy
 import pickle
 import unittest
 
@@ -156,6 +157,7 @@ param=yyy
         node = n.node_from_dict(input_dict)
         output_dict = n.node_to_dict(node)
         self.assertEqual(input_dict, output_dict)
+        copy.deepcopy(node)  # check it does not raise an error
 
     def test_can_pickle(self):
         node = n.Node('tag')

--- a/openquake/commonlib/tests/node_test.py
+++ b/openquake/commonlib/tests/node_test.py
@@ -157,7 +157,9 @@ param=yyy
         node = n.node_from_dict(input_dict)
         output_dict = n.node_to_dict(node)
         self.assertEqual(input_dict, output_dict)
-        copy.deepcopy(node)  # check it does not raise an error
+
+        # test deepcopy
+        self.assertEqual(node, copy.deepcopy(node))
 
     def test_can_pickle(self):
         node = n.Node('tag')

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.tom import PoissonTOM
 
 from openquake.commonlib import tests, nrml_examples, readinput
 from openquake.commonlib import sourceconverter as s
-from openquake.commonlib.source import parse_source_model, DuplicatedID
+from openquake.commonlib.source import SourceModelParser, DuplicatedID
 from openquake.commonlib.nrml import nodefactory
 from openquake.commonlib.node import read_nodes
 from openquake.baselib.general import assert_close
@@ -75,17 +75,17 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.converter = s.SourceConverter(
+        cls.parser = SourceModelParser(s.SourceConverter(
             investigation_time=50.,
             rupture_mesh_spacing=1,  # km
             complex_fault_mesh_spacing=1,  # km
             width_of_mfd_bin=1.,  # for Truncated GR MFDs
             area_source_discretization=1.,  # km
-        )
+        ))
         source_nodes = read_nodes(MIXED_SRC_MODEL, filter_sources, ValidNode)
         (cls.area, cls.point, cls.simple, cls.cmplx, cls.char_simple,
          cls.char_complex, cls.char_multi) = map(
-            cls.converter.convert_node, source_nodes)
+            cls.parser.converter.convert_node, source_nodes)
         # the parameters here would typically be specified in the job .ini
         cls.investigation_time = 50.
         cls.rupture_mesh_spacing = 1  # km
@@ -371,16 +371,15 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
         assert_close(self._expected_char_multi, self.char_multi)
 
     def test_duplicate_id(self):
-        converter = s.SourceConverter(  # different from self.converter
+        parser = SourceModelParser(s.SourceConverter(
             investigation_time=50.,
             rupture_mesh_spacing=1,
             complex_fault_mesh_spacing=1,
             width_of_mfd_bin=0.1,
             area_source_discretization=10,
-        )
+        ))
         with self.assertRaises(DuplicatedID):
-            parse_source_model(
-                DUPLICATE_ID_SRC_MODEL, converter)
+            parser.parse_sources(DUPLICATE_ID_SRC_MODEL)
 
     def test_raises_useful_error_1(self):
         area_file = BytesIO(b"""\
@@ -476,7 +475,7 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
 """)
         [area] = read_nodes(area_file, filter_sources, ValidNode)
         with self.assertRaises(NameError) as ctx:
-            self.converter.convert_node(area)
+            self.parser.converter.convert_node(area)
         self.assertIn(
             "node areaSource: No subnode named 'nodalPlaneDist'"
             " found in 'areaSource', line 5 of", str(ctx.exception))
@@ -537,7 +536,7 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
         msg = ('node simpleFaultSource: hypo_list and slip_list have to be '
                'both given')
         with self.assertRaises(ValueError) as ctx:
-            parse_source_model(simple_file, self.converter)
+            self.parser.parse_sources(simple_file)
         self.assertIn(msg, str(ctx.exception))
 
     def test_nonparametric_source_ok(self):
@@ -670,15 +669,14 @@ class TrtModelTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.converter = s.SourceConverter(
+        cls.parser = SourceModelParser(s.SourceConverter(
             investigation_time=50.,
             rupture_mesh_spacing=1,  # km
             complex_fault_mesh_spacing=1,  # km
             width_of_mfd_bin=1.,  # for Truncated GR MFDs
-            area_source_discretization=1.)
-        cls.source_collector = dict(
-            (sc.trt, sc) for sc in parse_source_model(
-                MIXED_SRC_MODEL, cls.converter, lambda src: None))
+            area_source_discretization=1.))
+        cls.source_collector = {
+            sc.trt: sc for sc in cls.parser.parse_trt_models(MIXED_SRC_MODEL)}
         cls.sitecol = site.SiteCollection(cls.SITES)
 
     def check(self, trt, attr, value):

--- a/openquake/commonlib/tests/sourcewriter_test.py
+++ b/openquake/commonlib/tests/sourcewriter_test.py
@@ -39,12 +39,14 @@ class SourceWriterTestCase(unittest.TestCase):
         self.check_round_trip(ALT_MFDS)
 
 
-# deep-copied sources must be serializable
 class DeepcopyTestCase(unittest.TestCase):
-    def test(self):
+    def test_is_writeable(self):
         parser = SourceModelParser(SourceConverter(50., 1., 10, 0.1, 10.))
         [sf, cf] = map(copy.deepcopy, parser.parse_sources(ALT_MFDS))
         # there are a SimpleFaultSource and a CharacteristicFaultSource
         fd, fname = tempfile.mkstemp(suffix='.xml')
         with os.fdopen(fd, 'w'):
             write_source_model(fname, [sf, cf], 'Test Source Model')
+        # NB: without Node.__deepcopy__ the serialization would fail
+        # with a RuntimeError: maximum recursion depth exceeded while
+        # calling a Python object

--- a/openquake/commonlib/tests/sourcewriter_test.py
+++ b/openquake/commonlib/tests/sourcewriter_test.py
@@ -43,8 +43,8 @@ class SourceWriterTestCase(unittest.TestCase):
 class DeepcopyTestCase(unittest.TestCase):
     def test(self):
         parser = SourceModelParser(SourceConverter(50., 1., 10, 0.1, 10.))
-        sources = map(copy.deepcopy, parser.parse_sources(ALT_MFDS))
-        sf, cf = sources  # SimpleFaultSource and CharacteristicFaultSource
+        [sf, cf] = map(copy.deepcopy, parser.parse_sources(ALT_MFDS))
+        # there are a SimpleFaultSource and a CharacteristicFaultSource
         fd, fname = tempfile.mkstemp(suffix='.xml')
         with os.fdopen(fd, 'w'):
-            write_source_model(fname, sources, 'Test Source Model')
+            write_source_model(fname, [sf, cf], 'Test Source Model')


### PR DESCRIPTION
This is an optimization useful in cases of large source model logic trees, when a specific source model file has to be considered several times. For instance in our demo [LogicTreeCase2ClassicalPSHA](https://github.com/gem/oq-risklib/blob/engine-1.7/demos/hazard/LogicTreeCase2ClassicalPSHA/report.rst) the file `source_model.xml` is considered 81 times.
In the current master we parse the same file 81 times and we re-instantiate and re-validate the
sources 81 times; with this pull request the file will be parsed only once and the sources validated only once, then we will make 81 copies of the sources and we will apply the uncertainties to the copies.

This makes a difference especially for the command ``oq-lite info --report``. In our demo the time to read the composite source model goes down from 12s to 6s. In more complex cases the speedup can be even bigger.

PS: while working at this feature I discovered a few subtle bugs in the Node class which have been fixed.

The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1336/
