### PR TITLE
Made possible to generate the report even for descriptions with non-ASCII characters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Made possible to generate the report even for descriptions with
+    non-ASCII characters
   * Added a tag `riskInvestigationTime` to the exported loss maps and curves
   * Made customizable the header of CSV files
 

--- a/demos/hazard/AreaSourceClassicalPSHA/job.ini
+++ b/demos/hazard/AreaSourceClassicalPSHA/job.ini
@@ -1,6 +1,6 @@
 [general]
 
-description = Classical PSHA using Area Source
+description = Classical PSHA — Area Source
 calculation_mode = classical
 concurrent_tasks = 4
 random_seed = 23

--- a/openquake/commonlib/reportwriter.py
+++ b/openquake/commonlib/reportwriter.py
@@ -30,7 +30,7 @@ import logging
 from openquake.baselib.general import humansize
 from openquake.commonlib import readinput, datastore, source, parallel
 from openquake.commonlib.oqvalidation import OqParam
-from openquake.calculators import base, views
+from openquake.calculators import base
 
 
 def indent(text):
@@ -60,7 +60,8 @@ class ReportWriter(object):
     def __init__(self, dstore):
         self.dstore = dstore
         self.oq = oq = OqParam.from_(dstore.attrs)
-        self.text = oq.description + '\n' + '=' * len(oq.description)
+        self.text = (oq.description.encode('utf8') + '\n' +
+                     '=' * len(oq.description))
         # NB: in the future, the sitecol could be transferred as
         # an array by leveraging the HDF5 serialization protocol in
         # litetask decorator; for the moment however the size of the


### PR DESCRIPTION
I discovered the issue in Anirudh's California calculation: while the calculation runs, and even

```bash
$ oq-lite show fullreport
```

works (because the default encoding for the terminal is UTF-8),

```bash
$ oq-lite show fullreport > report.rst
```

fails with an error

```python
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2014' in position 23: ordinal not in range(128)
```

The solution is to encode the description as UTF-8 explicitly. I am adding a non-ASCII dash character to the AreaSource demo to test the report generation.