### PR TITLE
Discriminating does not exist versus cannot access

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Discriminate the case of a missing datastore from the case of having no
+    permission to access it
   * Saved half the space in absence of insured_losses in the event based risk
     calculator
   * Rewritten the CSV exporters for dmg_by_asset, dmg_by_taxo and dmg_total

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -105,6 +105,10 @@ def get_last_calc_id(datadir):
     return calcs[-1]
 
 
+# a workaround against a deficiency of Python: os.path.exists and
+# os.access(path, os.F_OK) both gives False when the file exists
+# but it is not accessible; so we have to check that all the
+# parent directories are accessible manually; this is rather ugly
 def extract_paths(fname):
     """
     >>> extract_paths('/a/b/c')

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -117,10 +117,11 @@ def read(calc_id, mode='r', datadir=DATADIR):
     if calc_id < 0:  # retrieve an old datastore
         calc_id = get_calc_ids(datadir)[calc_id]
     fname = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
-    if not os.path.exists(fname):
-        raise OSError('File not found: %r' % fname)
-    if not os.access(fname, os.R_OK if mode == 'r' else os.W_OK):
-        raise OSError('No permission to access %r' % fname)
+    for path in (datadir, fname):
+        if not os.access(path, os.F_OK):
+            raise IOError('No such file or directory: %r' % path)
+        elif not os.access(path, os.R_OK if mode == 'r' else os.W_OK):
+            raise OSError('No permission to access %r' % path)
     return DataStore(calc_id, datadir, mode=mode)
 
 

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -105,26 +105,6 @@ def get_last_calc_id(datadir):
     return calcs[-1]
 
 
-# a workaround against a deficiency of Python: os.path.exists and
-# os.access(path, os.F_OK) both gives False when the file exists
-# but it is not accessible; so we have to check that all the
-# parent directories are accessible manually; this is rather ugly
-def extract_paths(fname):
-    """
-    >>> extract_paths('/a/b/c')
-    ['/a', '/a/b', '/a/b/c']
-    """
-    paths = [fname]
-    path = fname
-    while True:
-        parent = os.path.dirname(path)
-        if parent == '/':
-            break
-        paths.append(parent)
-        path = parent
-    return paths[::-1]
-
-
 def read(calc_id, mode='r', datadir=DATADIR):
     """
     :param calc_id: calculation ID
@@ -137,11 +117,7 @@ def read(calc_id, mode='r', datadir=DATADIR):
     if calc_id < 0:  # retrieve an old datastore
         calc_id = get_calc_ids(datadir)[calc_id]
     fname = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
-    for path in extract_paths(fname):
-        if not os.access(path, os.F_OK):
-            raise IOError('No such file or directory: %r' % path)
-        elif not os.access(path, os.R_OK if mode == 'r' else os.W_OK):
-            raise OSError('No permission to access %r' % path)
+    open(fname).close()  # check if the file exists and is accessible
     return DataStore(calc_id, datadir, mode=mode)
 
 

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -105,6 +105,22 @@ def get_last_calc_id(datadir):
     return calcs[-1]
 
 
+def extract_paths(fname):
+    """
+    >>> extract_paths('/a/b/c')
+    ['/a', '/a/b', '/a/b/c']
+    """
+    paths = [fname]
+    path = fname
+    while True:
+        parent = os.path.dirname(path)
+        if parent == '/':
+            break
+        paths.append(parent)
+        path = parent
+    return paths[::-1]
+
+
 def read(calc_id, mode='r', datadir=DATADIR):
     """
     :param calc_id: calculation ID
@@ -117,7 +133,7 @@ def read(calc_id, mode='r', datadir=DATADIR):
     if calc_id < 0:  # retrieve an old datastore
         calc_id = get_calc_ids(datadir)[calc_id]
     fname = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
-    for path in (datadir, fname):
+    for path in extract_paths(fname):
         if not os.access(path, os.F_OK):
             raise IOError('No such file or directory: %r' % path)
         elif not os.access(path, os.R_OK if mode == 'r' else os.W_OK):

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -103,5 +103,6 @@ class DataStoreTestCase(unittest.TestCase):
         fname = os.path.join(tmp, 'calc_42.hdf5')
         open(fname, 'w').write('')
         os.chmod(fname, 0)
-        with self.assertRaises(OSError):
+        with self.assertRaises(IOError) as ctx:
             read(42, datadir=tmp)
+        self.assertIn('Permission denied:', unicode(ctx.exception))

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -17,9 +17,11 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import re
+import os
 import unittest
+import tempfile
 import numpy
-from openquake.commonlib.datastore import DataStore, view
+from openquake.commonlib.datastore import DataStore, view, read
 
 
 @view.add('key1_upper')
@@ -88,3 +90,18 @@ class DataStoreTestCase(unittest.TestCase):
         path = self.dstore.export_path('hello.txt')
         mo = re.match('\./hello_\d+', path)
         self.assertIsNotNone(mo)
+
+    def test_read(self):
+        # cas of a non-existing directory
+        with self.assertRaises(IOError):
+            read(42, datadir='/fake/directory')
+        # case of a non-existing file
+        with self.assertRaises(IOError):
+            read(42, datadir='/tmp')
+        # case of no read permission
+        tmp = tempfile.mkdtemp()
+        fname = os.path.join(tmp, 'calc_42.hdf5')
+        open(fname, 'w').write('')
+        os.chmod(fname, 0)
+        with self.assertRaises(OSError):
+            read(42, datadir=tmp)


### PR DESCRIPTION
Daniele was right and `os.path.exists` says that a file does not exist when it does not have permission to read it, even it exists. Fortunately `open` works correctly, so I am using that instead.