### PR TITLE
Fixed the case with statistics and no conditional_loss_poes

### DIFF
--- a/demos/risk/ClassicalDamage/job_hazard.ini
+++ b/demos/risk/ClassicalDamage/job_hazard.ini
@@ -27,3 +27,4 @@ intensity_measure_types_and_levels = {"PGA": [0.005, 0.0075, 0.01,  0.02, 0.03, 
 truncation_level = 3
 investigation_time = 1
 maximum_distance = 200.0
+export_dir = /tmp

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -550,7 +550,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         if not all_stats:
             return
         loss_curves = numpy.zeros((self.N, self.Q1), self.loss_curve_dt)
-        loss_maps = numpy.zeros((self.N, self.Q1), self.loss_maps_dt)
+        if oq.conditional_loss_poes:
+            loss_maps = numpy.zeros((self.N, self.Q1), self.loss_maps_dt)
         for stats in all_stats:
             # there is one stat for each loss_type
             cb = self.riskmodel.curve_builders[ltypes.index(stats.loss_type)]
@@ -562,7 +563,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                 oq.insured_losses)
             curves, maps = sb.get_curves_maps(stats)  # matrices (Q1, N)
             loss_curves[cb.loss_type] = curves.T
-            loss_maps[cb.loss_type] = maps.T
+            if oq.conditional_loss_poes:
+                loss_maps[cb.loss_type] = maps.T
 
         self.datastore['loss_curves-stats'] = loss_curves
         if oq.conditional_loss_poes:

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -102,6 +102,7 @@ a3        RM       8.574770E+01 2.790150E+01 1.441384E+02 0.000000E+00
 
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_3(self):
+        # this is a test with statistics and without conditional_loss_poes
         out = self.run_calc(case_3.__file__, 'job_haz.ini,job_risk.ini',
                             exports='xml', individual_curves='false',
                             concurrent_tasks='4')

--- a/openquake/qa_tests_data/event_based_risk/case_3/job_risk.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_3/job_risk.ini
@@ -11,6 +11,7 @@ structural_vulnerability_file = vulnerability_model2013.xml
 master_seed = 42
 asset_hazard_distance = 20
 loss_curve_resolution = 20
+loss_ratios = {'structural': [0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]}
 
 conditional_loss_poes =
 


### PR DESCRIPTION
I discovered this error while running the Indonesia computation:

```python
     File "/usr/local/openquake/oq-risklib/openquake/calculators/event_based_risk.py", line 553, in compute_store_stats
       loss_maps = numpy.zeros((self.N, self.Q1), self.loss_maps_dt)
   TypeError: Empty data-type
```

The solution was to add a couple of `if conditional_loss_poes`. I also made test_case_3 sensitive to this issue by simply producing some loss curves.