### PR TITLE
Collected the risk outputs in dictionaries (l, r) -> output

### DIFF
--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -44,8 +44,8 @@ def classical_bcr(riskinputs, riskmodel, rlzs_assoc, bcr_dt, monitor):
         :class:`openquake.baselib.performance.PerformanceMonitor` instance
     """
     result = {}  # (N, R) -> data
-    for out_by_rlz in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
-        for out in out_by_rlz:
+    for out_by_lr in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
+        for (l, r), out in sorted(out_by_lr.items()):
             for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
                 aval = asset.value(out.loss_type)
                 result[asset.idx, out.loss_type, out.hid] = numpy.array([

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -41,11 +41,11 @@ def classical_damage(riskinputs, riskmodel, rlzs_assoc, monitor):
     """
     with monitor:
         result = {i: AccumDict() for i in range(len(rlzs_assoc))}
-        for out_by_rlz in riskmodel.gen_outputs(
+        for out_by_lr in riskmodel.gen_outputs(
                 riskinputs, rlzs_assoc, monitor):
-            for out in out_by_rlz:
+            for (l, r), out in sorted(out_by_lr.items()):
                 asset_ids = [a.idx for a in out.assets]
-                result[out.hid] += dict(zip(asset_ids, out.damages))
+                result[r] += dict(zip(asset_ids, out.damages))
     return result
 
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -42,16 +42,13 @@ def classical_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
     :param monitor:
         :class:`openquake.baselib.performance.PerformanceMonitor` instance
     """
-    lti = riskmodel.lti
     oq = monitor.oqparam
     ins = oq.insured_losses
 
     result = dict(
         loss_curves=[], loss_maps=[], stat_curves=[], stat_maps=[])
-    for out_by_rlz in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
-        l = lti[out_by_rlz.loss_type]
-        for out in out_by_rlz:
-            r = out.hid
+    for out_by_lr in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
+        for (l, r), out in sorted(out_by_lr.items()):
             for i, asset in enumerate(out.assets):
                 aid = asset.idx
                 avg = out.average_losses[i]
@@ -73,15 +70,15 @@ def classical_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
                     (l, r, aid, out.loss_maps[:, i]))
 
         # compute statistics
-        if len(out_by_rlz) > 1:
+        if len(rlzs_assoc.realizations) > 1:
             curve_resolution = out.loss_curves.shape[-1]
             statsbuilder = scientific.StatsBuilder(
                 oq.quantile_loss_curves,
                 oq.conditional_loss_poes, oq.poes_disagg,
                 curve_resolution, insured_losses=oq.insured_losses)
-            stats = statsbuilder.build(out_by_rlz)
+            stats = statsbuilder.build(out_by_lr.values())
             stat_curves, stat_maps = statsbuilder.get_curves_maps(stats)
-            for i, asset in enumerate(out_by_rlz.assets):
+            for i, asset in enumerate(out_by_lr.assets):
                 result['stat_curves'].append((l, asset.idx, stat_curves[:, i]))
                 if len(stat_maps):
                     result['stat_maps'].append((l, asset.idx, stat_maps[:, i]))

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -17,9 +17,11 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import operator
 
 import numpy
 
+from openquake.baselib.general import groupby
 from openquake.risklib import scientific, riskinput
 from openquake.commonlib import readinput, parallel, datastore, logictree
 from openquake.calculators import base
@@ -45,7 +47,6 @@ def classical_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
     oq = monitor.oqparam
     ins = oq.insured_losses
     R = len(rlzs_assoc.realizations)
-    L = len(riskmodel.loss_types)
     result = dict(
         loss_curves=[], loss_maps=[], stat_curves=[], stat_maps=[])
     for out_by_lr in riskmodel.gen_outputs(riskinputs, rlzs_assoc, monitor):
@@ -72,13 +73,13 @@ def classical_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
 
         # compute statistics
         if R > 1:
-            curve_resolution = out.loss_curves.shape[-1]
-            statsbuilder = scientific.StatsBuilder(
-                oq.quantile_loss_curves,
-                oq.conditional_loss_poes, oq.poes_disagg,
-                curve_resolution, insured_losses=oq.insured_losses)
-            for l in range(L):
-                outs = [out_by_lr[l, r] for r in range(R)]
+            for l, lrs in groupby(out_by_lr, operator.itemgetter(0)).items():
+                outs = [out_by_lr[lr] for lr in lrs]
+                curve_resolution = outs[0].loss_curves.shape[-1]
+                statsbuilder = scientific.StatsBuilder(
+                    oq.quantile_loss_curves,
+                    oq.conditional_loss_poes, oq.poes_disagg,
+                    curve_resolution, insured_losses=oq.insured_losses)
                 stats = statsbuilder.build(outs)
                 stat_curves, stat_maps = statsbuilder.get_curves_maps(stats)
                 for i, asset in enumerate(out_by_lr.assets):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -142,7 +142,7 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, assets_by_site,
 
             # aggregate losses per rupture
             for rup_id, all_losses, ins_losses in zip(
-                    out.tags, out.event_loss_per_asset,
+                    out.rupids, out.event_loss_per_asset,
                     out.insured_loss_per_asset):
                 for aid, groundloss, insuredloss in zip(
                         asset_ids, all_losses, ins_losses):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -135,11 +135,9 @@ def event_based_risk(riskinputs, riskmodel, rlzs_assoc, assets_by_site,
     if monitor.avg_losses:
         result['AVGLOSS'] = square(L, R, zeroN2)
     ass_losses = []
-    for out_by_rlz in riskmodel.gen_outputs(
+    for out_by_lr in riskmodel.gen_outputs(
             riskinputs, rlzs_assoc, monitor, assets_by_site):
-        for out in out_by_rlz:
-            l = lti[out.loss_type]
-            r = out.hid
+        for (l, r), out in sorted(out_by_lr.items()):
             asset_ids = [a.idx for a in out.assets]
 
             # aggregate losses per rupture

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -104,14 +104,11 @@ def scenario_damage(riskinputs, riskmodel, rlzs_assoc, monitor):
     E = monitor.oqparam.number_of_ground_motion_fields
     T = len(monitor.taxonomies)
     taxo2idx = {taxo: i for i, taxo in enumerate(monitor.taxonomies)}
-    lt2idx = {lt: i for i, lt in enumerate(riskmodel.loss_types)}
     result = dict(d_asset=[], d_taxon=numpy.zeros((T, L, R, E, D), F64),
                   c_asset=[], c_taxon=numpy.zeros((T, L, R, E), F64))
-    for out_by_rlz in riskmodel.gen_outputs(
+    for out_by_lr in riskmodel.gen_outputs(
             riskinputs, rlzs_assoc, monitor):
-        for out in out_by_rlz:
-            l = lt2idx[out.loss_type]
-            r = out.hid
+        for (l, r), out in sorted(out_by_lr.items()):
             c_model = c_models.get(out.loss_type)
             for asset, fraction in zip(out.assets, out.damages):
                 t = taxo2idx[asset.taxonomy]

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -55,12 +55,9 @@ def scenario_risk(riskinputs, riskmodel, rlzs_assoc, monitor):
     L = len(riskmodel.loss_types)
     R = len(rlzs_assoc.realizations)
     result = dict(agg=numpy.zeros((E, L, R, 2), F64), avg=[])
-    lt2idx = {lt: i for i, lt in enumerate(riskmodel.loss_types)}
-    for out_by_rlz in riskmodel.gen_outputs(
+    for out_by_lr in riskmodel.gen_outputs(
             riskinputs, rlzs_assoc, monitor):
-        for out in out_by_rlz:
-            l = lt2idx[out.loss_type]
-            r = out.hid  # realization index
+        for (l, r), out in sorted(out_by_lr.items()):
             stats = numpy.zeros((len(out.assets), 4), F32)
             # this is ugly but using a composite array (i.e.
             # stats['mean'], stats['stddev'], ...) may return

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -351,7 +351,7 @@ class CompositeRiskModel(collections.Mapping):
         """
         Group the assets per taxonomy and compute the outputs by using the
         underlying riskmodels. Yield the outputs generated as dictionaries
-        out_by_rlz.
+        out_by_lr.
 
         :param riskinputs: a list of riskinputs with consistent IMT
         :param rlzs_assoc: a RlzsAssoc instance
@@ -378,9 +378,8 @@ class CompositeRiskModel(collections.Mapping):
                                 epsilons.append(epsilon)
                         if not assets:
                             continue
-                        for out_by_rlz in self[taxonomy].gen_out_by_rlz(
-                                imt, assets, hazards, epsilons, tags):
-                            yield out_by_rlz
+                        yield self[taxonomy].out_by_lr(
+                            imt, assets, hazards, epsilons, tags)
 
     def __repr__(self):
         lines = ['%s: %s' % item for item in sorted(self.items())]

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -360,7 +360,7 @@ class CompositeRiskModel(collections.Mapping):
         mon_hazard = monitor('getting hazard')
         mon_risk = monitor('computing individual risk')
         for riskinput in riskinputs:
-            tags = riskinput.tags
+            rupids = riskinput.rupids
             assets_by_site = getattr(
                 riskinput, 'assets_by_site', assets_by_site)
             with mon_hazard:
@@ -379,7 +379,7 @@ class CompositeRiskModel(collections.Mapping):
                         if not assets:
                             continue
                         yield self[taxonomy].out_by_lr(
-                            imt, assets, hazards, epsilons, tags)
+                            imt, assets, hazards, epsilons, rupids)
 
     def __repr__(self):
         lines = ['%s: %s' % item for item in sorted(self.items())]
@@ -414,7 +414,7 @@ class RiskInput(object):
                 taxonomies_set.add(asset.taxonomy)
             self.weight += len(assets)
         self.taxonomies = sorted(taxonomies_set)
-        self.tags = None  # for API compatibility with RiskInputFromRuptures
+        self.rupids = None  # for API compatibility with RiskInputFromRuptures
         self.eps_dict = eps_dict
 
     @property
@@ -497,7 +497,7 @@ class RiskInputFromRuptures(object):
         self.weight = len(ses_ruptures)
         self.imts = sorted(set(imt for imt, _ in imt_taxonomies))
         self.eps = epsilons  # matrix N x E, events in this block
-        self.tags = numpy.array([sr.ordinal for sr in ses_ruptures])
+        self.rupids = numpy.array([sr.ordinal for sr in ses_ruptures])
 
     def compute_expand_gmfs(self):
         """

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -268,10 +268,10 @@ class RiskModel(object):
         out_by_lr.rupids = tags
         loss_types = self.get_loss_types(imt)
         # extract the realizations from the first asset
-        for r, rlz in enumerate(sorted(hazards[0])):
-            hazs = [haz[rlz] for haz in hazards]  # hazard per each asset
-            for loss_type in loss_types:
+        for loss_type in loss_types:
+            for r, rlz in enumerate(sorted(hazards[0])):
                 l = self.compositemodel.lti[loss_type]
+                hazs = [haz[rlz] for haz in hazards]  # hazard per each asset
                 out = self(loss_type, assets, hazs, epsilons, tags)
                 if out:
                     out.hid = rlz.ordinal

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -253,26 +253,25 @@ class RiskModel(object):
         return [lt for lt in self.loss_types
                 if self.risk_functions[lt].imt == imt]
 
-    def out_by_lr(self, imt, assets, hazards, epsilons, tags):
+    def out_by_lr(self, imt, assets, hazards, epsilons, rupids):
         """
         :param imt: restrict the risk functions to this IMT
         :param assets: an array of assets of homogeneous taxonomy
         :param hazards: an array of dictionaries per each asset
         :param epsilons: an array of epsilons per each asset
-        :param tags: rupture tags
-
-        Yield lists out_by_lr
+        :param rupids: rupture indices
+        :returns: a dictionary (l, r) -> output
         """
         out_by_lr = AccumDict()
         out_by_lr.assets = assets
-        out_by_lr.rupids = tags
+        out_by_lr.rupids = rupids
         loss_types = self.get_loss_types(imt)
         # extract the realizations from the first asset
         for rlz in sorted(hazards[0]):
             r = rlz.ordinal
             hazs = [haz[rlz] for haz in hazards]  # hazard per each asset
             for loss_type in loss_types:
-                out = self(loss_type, assets, hazs, epsilons, tags)
+                out = self(loss_type, assets, hazs, epsilons, rupids)
                 if out:
                     l = self.compositemodel.lti[loss_type]
                     out.hid = r
@@ -397,7 +396,7 @@ class Classical(RiskModel):
             for lt, vf in vulnerability_functions.items()}
 
     def __call__(self, loss_type, assets, hazard_curves, _epsilons=None,
-                 _tags=None):
+                 _rupids=None):
         """
         :param str loss_type:
             the loss type considered
@@ -594,7 +593,7 @@ class ProbabilisticEventBased(RiskModel):
             average_insured_losses=average_insured_losses,
             counts_matrix=cb.build_counts(loss_matrix),
             insured_counts_matrix=icounts,
-            tags=event_ids)
+            rupids=event_ids)
 
 
 @registry.add('classical_bcr')
@@ -617,7 +616,7 @@ class ClassicalBCR(RiskModel):
         self.hazard_imtls = hazard_imtls
         self.lrem_steps_per_interval = lrem_steps_per_interval
 
-    def __call__(self, loss_type, assets, hazard, _eps=None, _tags=None):
+    def __call__(self, loss_type, assets, hazard, _eps=None, _rupids=None):
         self.assets = assets
         vf = self.risk_functions[loss_type]
         imls = self.hazard_imtls[vf.imt]
@@ -662,7 +661,7 @@ class Scenario(RiskModel):
         self.time_event = time_event
 
     def __call__(self, loss_type, assets, ground_motion_values, epsilons,
-                 _tags=None):
+                 _rupids=None):
         values = get_values(loss_type, assets, self.time_event)
         ok = ~numpy.isnan(values)
         if not ok.any():
@@ -715,7 +714,7 @@ class Damage(RiskModel):
         self.taxonomy = taxonomy
         self.risk_functions = fragility_functions
 
-    def __call__(self, loss_type, assets, gmfs, _epsilons=None, _tags=None):
+    def __call__(self, loss_type, assets, gmfs, _epsilons=None, _rupids=None):
         """
         :param loss_type: the loss type
         :param assets: a list of N assets of the same taxonomy
@@ -749,7 +748,7 @@ class ClassicalDamage(Damage):
         self.risk_investigation_time = risk_investigation_time
 
     def __call__(self, loss_type, assets, hazard_curves, _epsilons=None,
-                 _tags=None):
+                 _rupids=None):
         """
         :param loss_type: the loss type
         :param assets: a list of N assets of the same taxonomy

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -268,13 +268,14 @@ class RiskModel(object):
         out_by_lr.rupids = tags
         loss_types = self.get_loss_types(imt)
         # extract the realizations from the first asset
-        for loss_type in loss_types:
-            for r, rlz in enumerate(sorted(hazards[0])):
-                l = self.compositemodel.lti[loss_type]
-                hazs = [haz[rlz] for haz in hazards]  # hazard per each asset
+        for rlz in sorted(hazards[0]):
+            r = rlz.ordinal
+            hazs = [haz[rlz] for haz in hazards]  # hazard per each asset
+            for loss_type in loss_types:
                 out = self(loss_type, assets, hazs, epsilons, tags)
                 if out:
-                    out.hid = rlz.ordinal
+                    l = self.compositemodel.lti[loss_type]
+                    out.hid = r
                     out.weight = rlz.weight
                     out_by_lr[l, r] = out
         return out_by_lr


### PR DESCRIPTION
This is a small refactoring in preparation for https://github.com/gem/oq-risklib/issues/711.
The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1393/
Remember the conventions:

- `l`: loss type index
- `r`: realization index