### PR TITLE
Renamed loss_map-rlzs -> losses_by_asset

### DIFF
--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -132,5 +132,5 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             avglosses = numpy.zeros((N, R), multi_stat_dt)
             for (l, r, aid, stat) in result['avg']:
                 avglosses[ltypes[l]][aid, r] = stat
-            self.datastore['loss_map-rlzs'] = avglosses
+            self.datastore['losses_by_asset'] = avglosses
             self.datastore['agglosses-rlzs'] = agglosses

--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -52,7 +52,7 @@ class ScenarioRiskTestCase(CalculatorTestCase):
     def test_case_3(self):
         out = self.run_calc(case_3.__file__, 'job.ini', exports='csv')
 
-        [fname] = out['loss_map-rlzs', 'csv']
+        [fname] = out['losses_by_asset', 'csv']
         self.assertEqualFiles('expected/asset-loss.csv', fname)
 
         [fname] = out['agglosses-rlzs', 'csv']
@@ -63,10 +63,10 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         out = self.run_calc(occupants.__file__, 'job_haz.ini,job_risk.ini',
                             exports='csv,xml')
 
-        [fname] = out['loss_map-rlzs', 'xml']
+        [fname] = out['losses_by_asset', 'xml']
         self.assertEqualFiles('expected/loss_map.xml', fname)
 
-        [fname] = out['loss_map-rlzs', 'csv']
+        [fname] = out['losses_by_asset', 'csv']
         self.assertEqualFiles('expected/asset-loss.csv', fname)
 
         [fname] = out['agglosses-rlzs', 'csv']

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -320,7 +320,7 @@ def view_totlosses(token, dstore):
         stats = ('mean', 'mean_ins')
     else:
         stats = ('mean',)
-    avglosses = dstore['loss_map-rlzs'].value
+    avglosses = dstore['losses_by_asset'].value
     dtlist = [('%s-%s' % (name, stat), numpy.float32)
               for name in avglosses.dtype.names for stat in stats]
     zero = numpy.zeros(avglosses.shape[1:], numpy.dtype(dtlist))

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -103,7 +103,7 @@ def compactify(array):
 
 
 # this is used by classical_risk, event_based_risk and scenario_risk
-@export.add(('avg_losses-rlzs', 'csv'), ('loss_map-rlzs', 'csv'))
+@export.add(('avg_losses-rlzs', 'csv'), ('losses_by_asset', 'csv'))
 def export_avg_losses(ekey, dstore):
     """
     :param ekey: export key, i.e. a pair (datastore key, fmt)
@@ -115,7 +115,7 @@ def export_avg_losses(ekey, dstore):
     writer = writers.CsvWriter(fmt='%.6E')
     for rlz in rlzs:
         losses = avg_losses[:, rlz.ordinal]
-        dest = dstore.export_path('avg_losses-rlz%03d.csv' % rlz.ordinal)
+        dest = dstore.export_path('losses_by_asset-rlz%03d.csv' % rlz.ordinal)
         data = compose_arrays(assets, losses)
         writer.save(data, dest)
     return writer.getsaved()
@@ -577,7 +577,7 @@ def export_loss_maps_stats_xml_geojson(ekey, dstore):
 
 
 # this is used by scenario_risk
-@export.add(('loss_map-rlzs', 'xml'), ('loss_map-rlzs', 'geojson'))
+@export.add(('losses_by_asset', 'xml'), ('losses_by_asset', 'geojson'))
 def export_loss_map_xml_geojson(ekey, dstore):
     oq = OqParam.from_(dstore.attrs)
     unit_by_lt = {ct['name']: ct['unit'] for ct in dstore['cost_types']}


### PR DESCRIPTION
This was requested by Catalina in https://github.com/gem/oq-risklib/issues/709. The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1398