### PR TITLE
Trap errors when filtering sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Reporting the source_id when the filtering fails
+
 python-oq-risklib (0.12.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -18,6 +18,7 @@
 
 from __future__ import division
 import io
+import sys
 import ast
 import copy
 import math
@@ -29,6 +30,7 @@ from xml.etree import ElementTree as etree
 
 import numpy
 
+from openquake.baselib.python3compat import raise_
 from openquake.baselib.general import AccumDict, groupby, block_splitter
 from openquake.commonlib.node import read_nodes
 from openquake.commonlib import logictree, sourceconverter, parallel, valid
@@ -945,8 +947,14 @@ class SourceManager(object):
             filter_time = split_time = 0
             if self.filter_sources:
                 with filter_mon:
-                    sites = src.filter_sites_by_distance_to_source(
-                        self.maximum_distance, sitecol)
+                    try:
+                        sites = src.filter_sites_by_distance_to_source(
+                            self.maximum_distance, sitecol)
+                    except:
+                        etype, err, tb = sys.exc_info()
+                        msg = 'An error occurred with source id=%s: %s'
+                        msg %= (src.source_id, unicode(err))
+                        raise_(etype, msg, tb)
                 filter_time = filter_mon.dt
                 if sites is None:
                     continue


### PR DESCRIPTION
We should print the `source_id` of the source causing issues. This was discovered while investigating https://github.com/gem/oq-engine/issues/1965.