### PR TITLE
Added information about the rupture calculation

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -326,6 +326,7 @@ class HazardCalculator(BaseCalculator):
                         self.oqparam)
                     self.rlzs_assoc = self.csm.info.get_rlzs_assoc()
                     self.datastore['csm_info'] = self.rlzs_assoc.csm_info
+                    self.rup_info = {}
 
                     # we could manage limits here
                     self.job_info = readinput.get_job_info(

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -326,7 +326,7 @@ class HazardCalculator(BaseCalculator):
                         self.oqparam)
                     self.rlzs_assoc = self.csm.info.get_rlzs_assoc()
                     self.datastore['csm_info'] = self.rlzs_assoc.csm_info
-                    self.rup_info = {}
+                    self.rup_data = {}
 
                     # we could manage limits here
                     self.job_info = readinput.get_job_info(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -497,6 +497,11 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
                 'gmfs_nbytes'] = get_gmfs_nbytes(
                 len(self.sitecol), len(self.oqparam.imtls),
                 self.rlzs_assoc, sescollection)
+        numsites = self.datastore['rup_info']['numsites']
+        multiplicity = self.datastore['rup_info']['multiplicity']
+        spr = numpy.average(numsites, weights=multiplicity)
+        self.datastore.set_attrs('rup_info', sites_per_rupture=spr)
+        self.datastore.set_nbytes('rup_info')
 
 
 # ######################## GMF calculator ############################ #

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -32,8 +32,7 @@ from openquake.hazardlib.calc.filters import \
     filter_sites_by_distance_to_rupture
 from openquake.hazardlib.calc.hazard_curve import zero_curves
 from openquake.hazardlib import geo, site, calc
-from openquake.hazardlib.gsim.base import (
-    gsim_imt_dt, RuptureContext, ContextMaker)
+from openquake.hazardlib.gsim.base import gsim_imt_dt, ContextMaker
 from openquake.commonlib import readinput, parallel, datastore
 from openquake.commonlib.util import max_rel_diff_index
 
@@ -336,7 +335,7 @@ def compute_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):
     res = AccumDict({trt_model_id: sesruptures})
     res.calc_times = calc_times
     res.rup_info = numpy.array(rup_info, rup_info_dt)
-    res.trt = trt.replace(' ', '_')
+    res.trt = trt
     return res
 
 
@@ -441,7 +440,7 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
                 dset = self.rup_info[val.trt]
             except KeyError:
                 dset = self.rup_info[val.trt] = self.datastore.create_dset(
-                    'rup_info/' + val.trt, val.rup_info.dtype)
+                    'rup_data/' + val.trt, val.rup_info.dtype)
             dset.extend(val.rup_info)
 
     def zerodict(self):
@@ -514,7 +513,7 @@ class EventBasedRuptureCalculator(ClassicalCalculator):
             mul = numpy.average(multiplicity, weights=numsites)
             self.datastore.set_attrs(dset.name, sites_per_rupture=spr,
                                      multiplicity=mul)
-        self.datastore.set_nbytes('rup_info')
+        self.datastore.set_nbytes('rup_data')
 
 
 # ######################## GMF calculator ############################ #

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -27,7 +27,8 @@ from openquake.commonlib.riskmodels import get_risk_files
 GROUND_MOTION_CORRELATION_MODELS = ['JB2009']
 
 HAZARD_CALCULATORS = [
-    'classical', 'disaggregation', 'event_based', 'scenario']
+    'classical', 'disaggregation', 'event_based', 'scenario',
+    'event_based_rupture']
 
 RISK_CALCULATORS = [
     'classical_risk', 'event_based_risk', 'scenario_risk',

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -293,7 +293,7 @@ class TaskManager(object):
         # log a warning if too much memory is used
         if self.no_distribute:
             sent = 0
-            res = safely_call(self.task_func, args)
+            res = (self.task_func(*args), None, args[-1])
         else:
             piks = pickle_sequence(args)
             sent = sum(len(p) for p in piks)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -475,7 +475,7 @@ def get_source_models(oqparam, source_model_lt, in_memory=True):
         weight = rlz.weight / num_samples
         num_gsim_paths = (num_samples if oqparam.number_of_logic_tree_samples
                           else gsim_lt.get_num_paths())
-        logging.info('Read source model %d/%d with %d gsim realization(s)',
+        logging.info('Processed source model %d/%d with %d gsim path(s)',
                      i + 1, num_source_models, num_gsim_paths)
         yield source.SourceModel(
             sm, weight, smpath, trt_models, gsim_lt, i, num_samples)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -918,7 +918,6 @@ class SourceManager(object):
         self.monitor = monitor
         self.filter_sources = filter_sources
         self.num_tiles = num_tiles
-        self.rlzs_assoc = csm.info.get_rlzs_assoc()
         self.split_map = {}  # trt_model_id, source_id -> split sources
         self.source_chunks = []
         self.infos = {}  # trt_model_id, source_id -> SourceInfo tuple
@@ -1017,6 +1016,7 @@ class SourceManager(object):
             maxweight = math.ceil(self.csm.maxweight * self.num_tiles / 4)
         else:
             maxweight = self.csm.maxweight
+        rlzs_assoc = self.csm.info.get_rlzs_assoc()
         for kind in ('light', 'heavy'):
             sources = list(self.get_sources(kind, sitecol))
             if not sources:
@@ -1031,7 +1031,7 @@ class SourceManager(object):
                     operator.attrgetter('weight'),
                     operator.attrgetter('trt_model_id')):
                 sent = self.tm.submit(block, sitecol, siteidx,
-                                      self.rlzs_assoc, self.monitor.new())
+                                      rlzs_assoc, self.monitor.new())
                 self.source_chunks.append((len(block), block.weight, sent))
                 nblocks += 1
             logging.info('Sent %d sources in %d block(s)',

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -430,10 +430,12 @@ class RiskInput(object):
         """Return a list of pairs (imt, taxonomies) with a single element"""
         return [(self.imt, self.taxonomies)]
 
-    def get_hazard(self, rlzs_assoc):
+    def get_hazard(self, rlzs_assoc, monitor):
         """
         :param rlzs_assoc:
             :class:`openquake.commonlib.source.RlzsAssoc` instance
+        :param monitor:
+            a :class:`openquake.baselib.performance.Monitor` instance
         :returns:
             list of hazard dictionaries imt -> rlz -> haz per each site
         """
@@ -522,6 +524,8 @@ class RiskInputFromRuptures(object):
         """
         :param rlzs_assoc:
             :class:`openquake.commonlib.source.RlzsAssoc` instance
+        :param monitor:
+            a :class:`openquake.baselib.performance.Monitor` instance
         :returns:
             lists of hazard dictionaries imt -> rlz -> haz
         """

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -23,6 +23,7 @@ import collections
 import numpy
 
 from openquake.baselib.python3compat import zip
+from openquake.baselib.performance import Monitor
 from openquake.baselib.general import groupby, split_in_blocks
 from openquake.hazardlib.gsim.base import gsim_imt_dt
 from openquake.risklib import scientific, riskmodels
@@ -430,7 +431,7 @@ class RiskInput(object):
         """Return a list of pairs (imt, taxonomies) with a single element"""
         return [(self.imt, self.taxonomies)]
 
-    def get_hazard(self, rlzs_assoc, monitor):
+    def get_hazard(self, rlzs_assoc, monitor=Monitor()):
         """
         :param rlzs_assoc:
             :class:`openquake.commonlib.source.RlzsAssoc` instance
@@ -520,7 +521,7 @@ class RiskInputFromRuptures(object):
             gmfa[i] = expanded_gmf
         return gmfa  # array R x N
 
-    def get_hazard(self, rlzs_assoc, monitor):
+    def get_hazard(self, rlzs_assoc, monitor=Monitor()):
         """
         :param rlzs_assoc:
             :class:`openquake.commonlib.source.RlzsAssoc` instance

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -24,7 +24,6 @@ import numpy
 
 from openquake.baselib.python3compat import zip
 from openquake.baselib.general import groupby, split_in_blocks
-from openquake.baselib.performance import Monitor
 from openquake.hazardlib.gsim.base import gsim_imt_dt
 from openquake.risklib import scientific, riskmodels
 
@@ -370,7 +369,8 @@ class CompositeRiskModel(collections.Mapping):
                            for assets in assets_by_site]
             with mon_hazard:
                 # get assets, epsilons, hazard
-                hazard_by_site = riskinput.get_hazard(rlzs_assoc)
+                hazard_by_site = riskinput.get_hazard(
+                    rlzs_assoc, mon_hazard(measuremem=False))
             with mon_risk:
                 # compute the outputs with the appropriate riskmodels
                 for asset_dict, hazard in zip(asset_dicts, hazard_by_site):
@@ -498,7 +498,7 @@ class RiskInputFromRuptures(object):
         self.eps = epsilons  # matrix N x E, events in this block
         self.rupids = numpy.array([sr.ordinal for sr in ses_ruptures])
 
-    def compute_expand_gmfs(self):
+    def compute_expand_gmfs(self, monitor):
         """
         :returns:
             an array R x N where N is the number of sites and
@@ -507,7 +507,7 @@ class RiskInputFromRuptures(object):
         from openquake.calculators.event_based import make_gmfs
         gmfs = make_gmfs(
             self.ses_ruptures, self.sitecol, self.imts,
-            self.gsims, self.trunc_level, self.correl_model, Monitor())
+            self.gsims, self.trunc_level, self.correl_model, monitor)
         gmf_dt = gsim_imt_dt(self.gsims, self.imts)
         N = len(self.sitecol.complete)
         R = len(gmfs)
@@ -518,14 +518,14 @@ class RiskInputFromRuptures(object):
             gmfa[i] = expanded_gmf
         return gmfa  # array R x N
 
-    def get_hazard(self, rlzs_assoc):
+    def get_hazard(self, rlzs_assoc, monitor):
         """
         :param rlzs_assoc:
             :class:`openquake.commonlib.source.RlzsAssoc` instance
         :returns:
             lists of hazard dictionaries imt -> rlz -> haz
         """
-        gmfs = self.compute_expand_gmfs()
+        gmfs = self.compute_expand_gmfs(monitor)
         gsims = list(map(str, self.gsims))
         trt_id = rlzs_assoc.csm_info.get_trt_id(self.col_id)
         hazs = []


### PR DESCRIPTION
To test:

1. run an event based calculation and look in the datastore into `rup_data`
2. see the additional time information about GMF generation (`oq-lite show performance`)

The demos are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1417/

Closes https://github.com/gem/oq-risklib/issues/735