### PR TITLE
setup.py: remove upper limit in psutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'numpy',
         'scipy',
         'decorator',
-        'psutil >= 0.4.1, < 3.0.0',
+        'psutil >= 0.4.1',
     ],
     author='GEM Foundation',
     author_email='devops@openquake.org',


### PR DESCRIPTION
Upper limit is blocking port to Ubuntu 16.04. The first tests I did with Ubuntu 16.04 look fine, if we'll found issues with psutil > 3.0 we will need to fix the code anyway.