### PR TITLE
Made calc_id visible in the string representation of Pickled objects

### DIFF
--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -161,11 +161,13 @@ class Pickled(object):
     """
     def __init__(self, obj):
         self.clsname = obj.__class__.__name__
+        self.calc_id = str(getattr(obj, 'calc_id', ''))  # for monitors
         self.pik = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
 
     def __repr__(self):
         """String representation of the pickled object"""
-        return '<Pickled %s %s>' % (self.clsname, humansize(len(self)))
+        return '<Pickled %s %s %s>' % (
+            self.clsname, self.calc_id, humansize(len(self)))
 
     def __len__(self):
         """Length of the pickled bytestring"""


### PR DESCRIPTION
This was requested by Daniele. In this way it is possible to inspect the celery arguments and to determine the calculation ID that produced a given task in this way:

```python
>>> import celery.task.control
>>> ins = celery.task.control.inspect()
>>> ins.active()
```
One will get an output like this:
```
{u'acknowledged': False,
   u'args': u'(<Pickled WeightedSequence  5.85 KB>, <Pickled SiteCollection  437 B>, <Pickled int  5 B>, <Pickled RlzsAssoc  16.31 KB>, <Pickled Monitor 4936 4.86 KB>)',
   u'delivery_info': {u'exchange': u'celery',
    u'priority': None,
    u'redelivered': False,
    u'routing_key': u'celery'}, ...
```
and the calculation ID can be extracted from the monitor object (`<Pickled Monitor 4936 4.86 KB>`,
the calc_id is 4936 in this example).