### PR TITLE
Added a check on the IMTs coming from the risk models

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check on the IMTs coming from the risk models
   * Changed the aggregate loss table exporter to export the event tags,
     not the event IDs
   * Fixed a bug with the CSV export of the ground motion fields

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -21,6 +21,7 @@ import logging
 import collections
 import numpy
 
+from openquake.hazardlib.imt import from_string
 from openquake.commonlib import valid, parallel, logictree
 from openquake.commonlib.riskmodels import get_risk_files
 
@@ -239,6 +240,7 @@ class OqParam(valid.ParamSet):
         for taxonomy, risk_functions in risk_models.items():
             for loss_type, rf in risk_functions.items():
                 imt = rf.imt
+                from_string(imt)  # make sure it is a valid IMT
                 imls = list(rf.imls)
                 if imt in imtls and imtls[imt] != imls:
                     logging.debug(

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -309,3 +309,11 @@ class OqParamTestCase(unittest.TestCase):
         self.assertIn("The `uniform_hazard_spectra` can be True only if "
                       "the IMT set contains SA(...) or PGA",
                       str(ctx.exception))
+
+    def test_set_risk_imtls(self):
+        oq = object.__new__(OqParam)
+        vf = mock.Mock(imt=' SA(0.1)', imls=[0.1, 0.2])
+        rm = dict(taxo=dict(structural=vf))
+        with self.assertRaises(ValueError) as ctx:
+            oq.set_risk_imtls(rm)
+        self.assertIn("Unknown IMT: ' SA(0.1)'", str(ctx.exception))


### PR DESCRIPTION
Catalina had a computation with a wrong IMT in the vulnerability functions. With this PR the error is raised early, before running the computation and not in the middle of it.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1451/