### PR TITLE
oq-lite show all is now safe

### DIFF
--- a/openquake/commonlib/commands/show.py
+++ b/openquake/commonlib/commands/show.py
@@ -69,9 +69,8 @@ def show(what, calc_id=-1):
             except:
                 # invalid datastore file, or missing calculation_mode
                 # and description attributes, perhaps due to a manual kill
-                logging.warn('Removed invalid calculation %d', calc_id)
-                os.remove(
-                    os.path.join(datastore.DATADIR, 'calc_%s.hdf5' % calc_id))
+                f = os.path.join(datastore.DATADIR, 'calc_%s.hdf5' % calc_id)
+                logging.warn('Unreadable datastore %s', f)
                 continue
             else:
                 rows.append((calc_id, cmode, descr.encode('utf-8')))


### PR DESCRIPTION
In the past the command `oq-lite show all` was automatically removing all unreadable datastores. This is now fixed because there is a very common case for unreadable datastore that must be considered valid, i.e. a change of version. The old datastore must not be deleted, since it can be read just going back to the version used to write it.