### PR TITLE
The loss maps and curves XML exporters now export the coordinates of the assets, not of the closest hazard site

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * The loss maps and curves XML exporters now export the coordinates
+    of the assets, not the coordinates of the closest hazard site
   * Stored the job.ini parameters into a table in the datastore
   * Added a check on the IMTs coming from the risk models
   * Changed the aggregate loss table exporter to export the event tags,

--- a/openquake/calculators/tests/classical_risk_test.py
+++ b/openquake/calculators/tests/classical_risk_test.py
@@ -84,7 +84,7 @@ class ClassicalRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/loss_curves-mean-structural.xml',
                               fname)
 
-    # this is a test with 1 hazard site and 2 risk sites
+    # test with 1 hazard site and 2 risk sites using assoc_assets_sites
     @attr('qa', 'risk', 'classical_risk')
     def test_case_5(self):
         # test with different curve resolution for different taxonomies

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -196,7 +196,6 @@ def export_avglosses_csv(ekey, dstore):
     :param dstore: datastore object
     """
     outs = extract_outputs(ekey[0], dstore, ext=ekey[1])
-    sitemesh = dstore['sitemesh']
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
     header = ['lon', 'lat', 'asset_ref', 'asset_value', 'average_loss',
@@ -204,8 +203,7 @@ def export_avglosses_csv(ekey, dstore):
     for out in outs:
         rows = []
         for asset, loss in zip(assetcol, out.array):
-            loc = sitemesh[asset['site_id']]
-            row = [loc['lon'], loc['lat'], aref[asset['idx']],
+            row = [asset['lon'], asset['lat'], aref[asset['idx']],
                    asset[out.ltype], loss, numpy.nan, out.ltype]
             rows.append(row)
         writers.write_csv(out.path, [header] + rows)
@@ -251,7 +249,6 @@ def export_damage(ekey, dstore):
     dmg_by_asset = dstore['dmg_by_asset']  # shape (N, L, R)
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     dmg_states = [DmgState(s, i) for i, s in enumerate(damage_states)]
     D = len(dmg_states)
     N, R = dmg_by_asset.shape
@@ -264,11 +261,10 @@ def export_damage(ekey, dstore):
         suffix = '' if L == 1 and R == 1 else '-gsimltp_%s_%s' % (rlz.uid, lt)
 
         dd_asset = []
-        for n in range(N):
-            assref = aref[assetcol[n]['idx']]
+        for n, ass in enumerate(assetcol):
+            assref = aref[ass['idx']]
             dist = dmg_by_asset[n, r][lt]
-            point = sitemesh[assetcol[n]['site_id']]
-            site = Site(point['lon'], point['lat'])
+            site = Site(ass['lon'], ass['lat'])
             for ds in range(D):
                 dd_asset.append(
                     DmgDistPerAsset(
@@ -503,9 +499,9 @@ LossCurve = collections.namedtuple(
 
 # emulate a Django point
 class Location(object):
-    def __init__(self, xy):
-        self.x, self.y = xy
-        self.wkt = 'POINT(%s %s)' % tuple(xy)
+    def __init__(self, x, y):
+        self.x, self.y = x, y
+        self.wkt = 'POINT(%s %s)' % (x, y)
 
 
 # used by event_based_risk and classical_risk
@@ -519,7 +515,6 @@ def export_loss_maps_rlzs_xml_geojson(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
     R = len(rlzs)
-    sitemesh = dstore['sitemesh']
     fnames = []
     export_type = ekey[1]
     writercls = (risk_writers.LossMapGeoJSONWriter
@@ -545,7 +540,7 @@ def export_loss_maps_rlzs_xml_geojson(ekey, dstore):
                     data = []
                     poe_str = 'poe~%s' % poe + ins
                     for ass, stat in zip(assetcol, lmaps[poe_str]):
-                        loc = Location(sitemesh[ass['site_id']])
+                        loc = Location(ass['lon'], ass['lat'])
                         lm = LossMap(loc, aref[ass['idx']], stat, None)
                         data.append(lm)
                     writer = writercls(
@@ -565,7 +560,6 @@ def export_loss_maps_stats_xml_geojson(ekey, dstore):
     N, S = loss_maps.shape
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     fnames = []
     export_type = ekey[1]
     writercls = (risk_writers.LossMapGeoJSONWriter
@@ -580,7 +574,7 @@ def export_loss_maps_stats_xml_geojson(ekey, dstore):
         curves = []
         poe_str = 'poe~%s' % poe + ins
         for ass, val in zip(assetcol, array[poe_str]):
-            loc = Location(sitemesh[ass['site_id']])
+            loc = Location(ass['lon'], ass['lat'])
             curve = LossMap(loc, aref[ass['idx']], val, None)
             curves.append(curve)
         writer.serialize(curves)
@@ -600,7 +594,6 @@ def export_loss_map_xml_geojson(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
     R = len(rlzs)
-    sitemesh = dstore['sitemesh']
     L = len(loss_types)
     fnames = []
     export_type = ekey[1]
@@ -624,7 +617,7 @@ def export_loss_map_xml_geojson(ekey, dstore):
                 data = []
                 for ass, mean, stddev in zip(
                         assetcol, means[:, r], stddevs[:, r]):
-                    loc = Location(sitemesh[ass['site_id']])
+                    loc = Location(ass['lon'], ass['lat'])
                     lm = LossMap(loc, aref[ass['idx']], mean, stddev)
                     data.append(lm)
                 writer = writercls(
@@ -764,7 +757,6 @@ def export_agg_curve(ekey, dstore):
 def export_loss_curves_stats(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     loss_curves = dstore[ekey[0]]
     ok_loss_types = loss_curves.dtype.names
     [loss_ratios] = dstore['loss_ratios']
@@ -780,7 +772,7 @@ def export_loss_curves_stats(ekey, dstore):
         array = loss_curves[ltype][:, s]
         curves = []
         for ass, rec in zip(assetcol, array):
-            loc = Location(sitemesh[ass['site_id']])
+            loc = Location(ass['lon'], ass['lat'])
             curve = LossCurve(loc, aref[ass['idx']], rec['poes' + ins],
                               rec['losses' + ins], loss_ratios[ltype],
                               rec['avg' + ins], None)
@@ -796,7 +788,6 @@ def export_loss_curves_stats(ekey, dstore):
 def export_rcurves_rlzs(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     rcurves = dstore[ekey[0]]
     [loss_ratios] = dstore['loss_ratios']
     fnames = []
@@ -810,7 +801,7 @@ def export_rcurves_rlzs(ekey, dstore):
         array = rcurves[ltype][:, r, ins]
         curves = []
         for ass, poes in zip(assetcol, array):
-            loc = Location(sitemesh[ass['site_id']])
+            loc = Location(ass['lon'], ass['lat'])
             losses = loss_ratios[ltype] * ass[ltype]
             avg = scientific.average_loss((losses, poes))
             curve = LossCurve(loc, aref[ass['idx']], poes,
@@ -827,7 +818,6 @@ def export_rcurves_rlzs(ekey, dstore):
 def export_loss_curves_rlzs(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     loss_curves = dstore[ekey[0]]
     fnames = []
     writercls = (risk_writers.LossCurveGeoJSONWriter
@@ -839,7 +829,7 @@ def export_loss_curves_rlzs(ekey, dstore):
         array = loss_curves[lt][:, r]
         curves = []
         for ass, data in zip(assetcol, array):
-            loc = Location(sitemesh[ass['site_id']])
+            loc = Location(ass['lon'], ass['lat'])
             losses = data['losses' + ins]
             poes = data['poes' + ins]
             avg = data['avg' + ins]
@@ -861,7 +851,6 @@ BcrData = collections.namedtuple(
 def export_bcr_map_rlzs(ekey, dstore):
     assetcol = dstore['assetcol/array'].value
     aref = dstore['asset_refs'].value
-    sitemesh = dstore['sitemesh']
     bcr_data = dstore['bcr-rlzs']
     N, R = bcr_data.shape
     oq = dstore['oqparam']
@@ -879,7 +868,7 @@ def export_bcr_map_rlzs(ekey, dstore):
                 **get_paths(rlz))
             data = []
             for ass, value in zip(assetcol, rlz_data):
-                loc = Location(sitemesh[ass['site_id']])
+                loc = Location(ass['lon'], ass['lat'])
                 data.append(BcrData(loc, aref[ass['idx']],
                                     value['annual_loss_orig'],
                                     value['annual_loss_retro'],

--- a/openquake/qa_tests_data/classical_risk/case_5/expected/loss_curves-mean.xml
+++ b/openquake/qa_tests_data/classical_risk/case_5/expected/loss_curves-mean.xml
@@ -15,7 +15,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <gml:Point>
                 <gml:pos>
-                    -78.18 15.613
+                    -78.168 15.5933
                 </gml:pos>
             </gml:Point>
             <poEs>
@@ -36,7 +36,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <gml:Point>
                 <gml:pos>
-                    -78.18 15.613
+                    -78.1681 15.5933
                 </gml:pos>
             </gml:Point>
             <poEs>


### PR DESCRIPTION
Closes https://github.com/gem/oq-risklib/issues/752.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-risklib/1462