### PR TITLE
Worked around a limitation of numpy 1.6

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -388,8 +388,11 @@ def get_gmvs_by_sid(gmfa):
     """
     Returns a dictionary sid -> array of composite ground motion values
     """
-    return groupby(gmfa, operator.itemgetter('sid'), lambda group:
-                   numpy.array([record['gmv'] for record in group]))
+    def to_array(group):  # this works with numpy 1.6 too
+        records = list(group)
+        return numpy.array([record['gmv'] for record in records], record['gmv'].dtype)
+    return groupby(gmfa, operator.itemgetter('sid'), to_array)
+                   
 
 
 def fix_minimum_intensity(min_iml, imts):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -390,7 +390,7 @@ def get_gmvs_by_sid(gmfa):
     """
     def to_array(group):  # this works with numpy 1.6 too
         records = list(group)
-        return numpy.array([record['gmv'] for record in records], record['gmv'].dtype)
+        return numpy.array([record['gmv'] for record in records], records[0]['gmv'].dtype)
     return groupby(gmfa, operator.itemgetter('sid'), to_array)
                    
 

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -62,9 +62,9 @@ class ScenarioHazardTestCase(CalculatorTestCase):
         [gmfa] = self.execute(case.__file__, 'job.ini').values()
         median = self.calc.oqparam.imtls.copy()
         gmvs_by_sid = get_gmvs_by_sid(gmfa)
-        gmf = numpy.array([gmvs_by_sid[sid] for sid in sorted(gmvs_by_sid)])
         for imt in median:
-            median[imt] = numpy.median(gmf[imt], axis=1)  # shape N
+            gmf = [gmvs_by_sid[sid][imt] for sid in sorted(gmvs_by_sid)]
+            median[imt] = numpy.median(gmf, axis=1)  # shape N
         return median
 
     @attr('qa', 'hazard', 'scenario')

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -46,8 +46,11 @@ def get_gmfa_by_eid(gmfa):
     Returns a dictionary sid -> array of composite ground motion values,
     ordered by sid by construction.
     """
-    return groupby(gmfa, operator.itemgetter('eid'), lambda records:
-                   numpy.array(list(records)))
+    def to_array(group):
+        records = list(group)
+        return numpy.array(records, records[0].dtype)
+    return groupby(gmfa, operator.itemgetter('eid'), to_array)
+
 
 
 class SES(object):


### PR DESCRIPTION
Setting trusty as default in Jenkins oq-risklib_zdevel was a bad idea. An issue with numpy 1.6 entered in master causing the breakage in https://ci.openquake.org/job/master_oq-risklib/2096/.
It is solved in this pull request. The default for oq-risklib_zdevel has been restored to precise.
We should raise the priority of the `/opt` project and make sure that we support numpy 1.8.2.

The tests are now green: https://ci.openquake.org/job/zdevel_oq-risklib/1512