### PR TITLE
Added a command `oq-lite info --exports`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a command `oq-lite info --exports`
   * Added a view displaying the calculation times by source typology
   * Fixed the test of GMPETable after the correction in hazardlib
   * Optimized the saving of the asset loss table

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -60,8 +60,11 @@ def info(calculators, gsims, views, exports, report, input_file=''):
     if exports:
         dic = groupby(export, operator.itemgetter(0),
                       lambda group: [r[1] for r in group])
+        n = 0
         for exporter, formats in dic.items():
             print(exporter, formats)
+            n += len(formats)
+        print('There are %d exporters defined.' % n)
     if input_file.endswith('.xml'):
         print(nrml.read(input_file).to_str())
     elif input_file.endswith(('.ini', '.zip')):

--- a/openquake/commonlib/commands/info.py
+++ b/openquake/commonlib/commands/info.py
@@ -18,8 +18,11 @@
 
 from __future__ import print_function
 import logging
+import operator
+from openquake.baselib.general import groupby
 from openquake.baselib.performance import Monitor
 from openquake.commonlib import sap, nrml, readinput, reportwriter, datastore
+from openquake.commonlib.export import export
 from openquake.calculators import base
 from openquake.hazardlib import gsim
 
@@ -39,7 +42,7 @@ def print_csm_info(fname):
 
 # the documentation about how to use this feature can be found
 # in the file effective-realizations.rst
-def info(calculators, gsims, views, report, input_file=''):
+def info(calculators, gsims, views, exports, report, input_file=''):
     """
     Give information. You can pass the name of an available calculator,
     a job.ini file, or a zip archive with the input files.
@@ -54,6 +57,11 @@ def info(calculators, gsims, views, report, input_file=''):
     if views:
         for name in sorted(datastore.view):
             print(name)
+    if exports:
+        dic = groupby(export, operator.itemgetter(0),
+                      lambda group: [r[1] for r in group])
+        for exporter, formats in dic.items():
+            print(exporter, formats)
     if input_file.endswith('.xml'):
         print(nrml.read(input_file).to_str())
     elif input_file.endswith(('.ini', '.zip')):
@@ -71,5 +79,6 @@ parser = sap.Parser(info)
 parser.flg('calculators', 'list available calculators')
 parser.flg('gsims', 'list available GSIMs')
 parser.flg('views', 'list available views')
+parser.flg('exports', 'list available exports')
 parser.flg('report', 'build a report in rst format')
 parser.arg('input_file', 'job.ini file or zip archive')

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -66,7 +66,7 @@ See https://github.com/gem/oq-risklib/blob/master/doc/effective-realizations.rst
     def test_zip(self):
         path = os.path.join(DATADIR, 'frenchbug.zip')
         with Print.patch() as p:
-            info(None, None, None, None, path)
+            info(None, None, None, None, None, path)
         self.assertEqual(self.EXPECTED, str(p))
 
 

--- a/openquake/commonlib/tests/commands_test.py
+++ b/openquake/commonlib/tests/commands_test.py
@@ -69,6 +69,31 @@ See https://github.com/gem/oq-risklib/blob/master/doc/effective-realizations.rst
             info(None, None, None, None, None, path)
         self.assertEqual(self.EXPECTED, str(p))
 
+    # poor man tests: checking that the flags produce a few characters
+    # (more than 10) and do not break; I am not checking the precise output
+
+    def test_calculators(self):
+        with Print.patch() as p:
+            info(True, None, None, None, None, '')
+        self.assertGreater(len(str(p)), 10)
+
+    def test_gsims(self):
+        with Print.patch() as p:
+            info(None, True, None, None, None, '')
+        self.assertGreater(len(str(p)), 10)
+
+    def test_views(self):
+        with Print.patch() as p:
+            info(None, None, True, None, None, '')
+        self.assertGreater(len(str(p)), 10)
+
+    def test_exports(self):
+        with Print.patch() as p:
+            info(None, None, None, True, None, '')
+        self.assertGreater(len(str(p)), 10)
+
+    # NB: info --report is tested manually once in a while
+
 
 class TidyTestCase(unittest.TestCase):
     def test_ok(self):


### PR DESCRIPTION
There are so many exporters that it is impossible to remember them. Enter

```
$ oq-lite info --exports
agg_curve-rlzs ['xml']
agg_curve-stats ['xml']
agg_loss_table ['csv']
agg_losses-rlzs ['csv']
agglosses-rlzs ['csv']
avg_losses-rlzs ['csv']
avg_losses-stats ['csv']
avglosses-rlzs ['csv']
bcr-rlzs ['xml']
csq_by_asset ['csv']
csq_by_taxon ['csv']
csq_total ['csv']
damages-rlzs ['csv']
disagg ['xml']
dmg_by_asset ['xml', 'csv']
dmg_by_taxon ['xml', 'csv']
dmg_total ['xml', 'csv']
gmf_data ['xml', 'txt', 'csv']
gmfs: ['csv']
hcurves ['csv', 'xml', 'geojson']
hmaps ['csv', 'xml', 'geojson']
loss_curves-rlzs ['csv', 'xml', 'geojson']
loss_curves-stats ['xml', 'geojson']
loss_maps-rlzs ['csv', 'xml', 'geojson']
loss_maps-stats ['xml', 'geojson']
losses_by_asset ['csv', 'xml', 'geojson']
rcurves-rlzs ['csv', 'xml', 'geojson']
realizations ['csv']
sescollection ['xml', 'csv']
uhs ['csv', 'xml']
There are 51 exporters defined.
```